### PR TITLE
opens new tab for external portal banner link in ressources

### DIFF
--- a/udata_front/theme/gouvfr/templates/dataset/display.html
+++ b/udata_front/theme/gouvfr/templates/dataset/display.html
@@ -121,7 +121,7 @@
     {% if external_source(dataset) %}
         {{ banner_info(
             "fr-icon-external-link-line",
-            _("This dataset come from an external portal.&nbsp;<a href='{external_source}'>View the original source.</a>")
+            _("This dataset come from an external portal.&nbsp;<a href='{external_source}' target="_blank" >View the original source.</a>")
             .format(external_source=external_source(dataset))
         )}}
     {% endif %}


### PR DESCRIPTION
opens the external portal in a new tab at click on the link, when the dataset is flag as coming from an external source.

example : https://www.data.gouv.fr/fr/datasets/projet-de-loi-de-finances-pour-2016-plf-2016-jaune-personnels-affectes-dans-les-cabinets-ministeriels/

It depends on your preferences... well it's mine