### PR TITLE
Use @datagouv/select-a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - **breaking change** Migrate to Python 3.11 [#376](https://github.com/etalab/udata-front/pull/376)
 - Fix api urls locked on dev.data.gouv.fr [#401](https://github.com/datagouv/udata-front/pull/401)
+- Fix an error that blocks datasets search filters reset [#402](https://github.com/datagouv/udata-front/pull/402)
 
 ## 3.5.5 (2024-04-16)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "3.5.1.dev",
       "license": "LGPL-2.1-only",
       "dependencies": {
+        "@datagouv/select-a11y": "^3.6.1",
         "leaflet": "^1.9.4"
       },
       "devDependencies": {
-        "@conciergerie.dev/select-a11y": "^3.5.0",
         "@conciergerie.dev/vue-toaster": "^2.4.4",
         "@etalab/data.gouv.fr-components": "^1.13.12",
         "@etalab/udata-front-plugins-helper": "1.1.0",
@@ -2126,12 +2126,6 @@
         "w3c-keyname": "^2.2.4"
       }
     },
-    "node_modules/@conciergerie.dev/select-a11y": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@conciergerie.dev/select-a11y/-/select-a11y-3.5.0.tgz",
-      "integrity": "sha512-l4TI2y+lR9gAZwTD51YJhGOEg9DmyuMTP7xoFy6pMNYatD1j+lukE4GjsBGMZVw6q9UYvVIxz9zmjbNcioUeTg==",
-      "dev": true
-    },
     "node_modules/@conciergerie.dev/vue-toaster": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@conciergerie.dev/vue-toaster/-/vue-toaster-2.4.4.tgz",
@@ -2199,6 +2193,11 @@
       "dependencies": {
         "ms": "^2.1.1"
       }
+    },
+    "node_modules/@datagouv/select-a11y": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@datagouv/select-a11y/-/select-a11y-3.6.1.tgz",
+      "integrity": "sha512-aidZY3eYsJL/FPfqyyJlzYmNz9jMRcm31ErUx+DNQSlDuOun2Rd2V83J4LD/WrC01FnghP9T/yFInjr++vTX7w=="
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -20431,12 +20430,6 @@
         "w3c-keyname": "^2.2.4"
       }
     },
-    "@conciergerie.dev/select-a11y": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@conciergerie.dev/select-a11y/-/select-a11y-3.5.0.tgz",
-      "integrity": "sha512-l4TI2y+lR9gAZwTD51YJhGOEg9DmyuMTP7xoFy6pMNYatD1j+lukE4GjsBGMZVw6q9UYvVIxz9zmjbNcioUeTg==",
-      "dev": true
-    },
     "@conciergerie.dev/vue-toaster": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@conciergerie.dev/vue-toaster/-/vue-toaster-2.4.4.tgz",
@@ -20498,6 +20491,11 @@
           }
         }
       }
+    },
+    "@datagouv/select-a11y": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@datagouv/select-a11y/-/select-a11y-3.6.1.tgz",
+      "integrity": "sha512-aidZY3eYsJL/FPfqyyJlzYmNz9jMRcm31ErUx+DNQSlDuOun2Rd2V83J4LD/WrC01FnghP9T/yFInjr++vTX7w=="
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "fsevents": "^2.3.3"
   },
   "devDependencies": {
-    "@conciergerie.dev/select-a11y": "^3.5.0",
     "@conciergerie.dev/vue-toaster": "^2.4.4",
     "@etalab/data.gouv.fr-components": "^1.13.12",
     "@etalab/udata-front-plugins-helper": "1.1.0",
@@ -101,6 +100,7 @@
   },
   "license": "LGPL-2.1-only",
   "dependencies": {
+    "@datagouv/select-a11y": "^3.6.1",
     "leaflet": "^1.9.4"
   }
 }

--- a/udata_front/theme/gouvfr/assets/js/components/MultiSelect/MultiSelect.vue
+++ b/udata_front/theme/gouvfr/assets/js/components/MultiSelect/MultiSelect.vue
@@ -48,7 +48,7 @@
             </template>
         </template>
         <template v-else>
-          <option 
+          <option
             v-for="option in displayedOptions"
             :key="option.value"
             :value="option.value"
@@ -74,7 +74,7 @@
 
 <script>
 import {defineComponent, ref, computed, onMounted, onUpdated, reactive, unref, watch, toValue} from "vue";
-import Select from "@conciergerie.dev/select-a11y";
+import Select from "@datagouv/select-a11y";
 import {useI18n} from 'vue-i18n';
 import axios from "axios";
 import {api, generateCancelToken} from "../../plugins/api";
@@ -263,7 +263,7 @@ export default defineComponent({
 
     /**
      * SelectA11y instance
-     * @type {import("vue").Ref<import("@conciergerie.dev/select-a11y").Select | null>}
+     * @type {import("vue").Ref<import("@datagouv/select-a11y").Select | null>}
      */
     const selectA11y = ref(null);
 

--- a/udata_front/theme/gouvfr/assets/js/components/MultiSelect/MultiSelect.vue
+++ b/udata_front/theme/gouvfr/assets/js/components/MultiSelect/MultiSelect.vue
@@ -650,9 +650,15 @@ export default defineComponent({
       }
     };
 
-    watch(() => props.values, () => {
-      let value = unref(normalizeValues(props.values));
-      selectA11y.value?.selectOptionSilently(value);
+    watch(() => props.values, async () => {
+      await fillSelectedFromValues();
+      if(Array.isArray(selected.value)) {
+        for(const value of selected.value) {
+          selectA11y.value?.selectOptionSilently(value);
+        }
+      } else {
+        selectA11y.value?.selectOptionSilently(selected.value ?? "");
+      }
     });
 
     const fillOptionsAndValues = suggestAndMapToOption()

--- a/udata_front/theme/gouvfr/assets/js/components/MultiSelect/MultiSelect.vue
+++ b/udata_front/theme/gouvfr/assets/js/components/MultiSelect/MultiSelect.vue
@@ -520,7 +520,7 @@ export default defineComponent({
       let selectedPromise = null;
       if (value && props.entityUrl) {
         selectedPromise = api
-          .get(props.entityUrl + value)
+          .get(`${props.entityUrl}${value}/`)
           .then((resp) => resp.data)
           .then((data) => mapToOption([data]))
           .then((entities) => entities[0]?.label ?? value)

--- a/udata_front/theme/gouvfr/assets/js/components/MultiSelect/MultiSelect.vue
+++ b/udata_front/theme/gouvfr/assets/js/components/MultiSelect/MultiSelect.vue
@@ -406,7 +406,7 @@ export default defineComponent({
         return option;
       });
       if(props.allOption) {
-        const existingAllOption = options.value.find(option => !option.value);
+        const existingAllOption = newOptions.find(option => !option.value);
         if(!existingAllOption) {
           newOptions.unshift({
             label: props.allOption,
@@ -565,6 +565,19 @@ export default defineComponent({
       }
     };
 
+     /**
+     * Register event listener to trigger on reset event
+     */
+     const registerTriggerOnReset = () => {
+      if(selectRef.value) {
+        if(props.multiple) {
+          selected.value = [];
+        } else {
+          selected.value = null;
+        }
+      }
+    };
+
     const updateStylesAndEvents = () => {
       updatePopupStyle();
       updateSelectStyle();
@@ -616,6 +629,8 @@ export default defineComponent({
       if(selectRef.value) {
         selectRef.value.removeEventListener('change', registerTriggerOnChange);
         selectRef.value.addEventListener('change', registerTriggerOnChange);
+        selectRef.value.removeEventListener('reset', registerTriggerOnReset);
+        selectRef.value.addEventListener('reset', registerTriggerOnReset);
       }
     };
 

--- a/udata_front/theme/gouvfr/assets/less/components/multiselect.less
+++ b/udata_front/theme/gouvfr/assets/less/components/multiselect.less
@@ -1,4 +1,4 @@
-@import (less) "@conciergerie.dev/select-a11y/dist/style.css";
+@import (less) "@datagouv/select-a11y/dist/style.css";
 .multiselect {
     &[data-selected=true] .select-a11y .select-a11y-button {
         color: @grey-500;


### PR DESCRIPTION
This PR uses the newly published `@datagouv/select-a11y` (https://github.com/datagouv/data.gouv.fr/issues/1317 for details).

Fixes https://github.com/datagouv/data.gouv.fr/issues/1270.


> [!NOTE]  
> `@datagouv/select-a11y` is moved from devDependencies to dependencies to help us distinguish dependencies used in udata-front, following https://github.com/datagouv/udata-front/pull/354. This is an ongoing process and all our dependencies aren't moved yet.
> They aren't really needed in the production environment because the js is bundled before.