### PR TITLE
Allow quality score warning to be hidden

### DIFF
--- a/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
+++ b/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Current (in progress)
+
+- Allow quality score warning to be hidden [#414](https://github.com/datagouv/udata-front/pull/414)

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/QualityComponent/QualityComponent.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/QualityComponent/QualityComponent.stories.ts
@@ -38,5 +38,31 @@ export const Quality: StoryObj<typeof meta> = {
       update_frequency: true,
       update_fulfilled_in_time: true,
     }
-  } 
+  }
+};
+
+export const QualityScoreWithoutWarning: StoryObj<typeof meta> = {
+  render: (args) => ({
+    components: { QualityComponent },
+    setup() {
+      return { args };
+    },
+    template: '<QualityComponent v-bind="args" />',
+  }),
+  args:{
+    quality: {
+      all_resources_available: false,
+      dataset_description_quality: false,
+      has_open_format: true,
+      has_resources: false,
+      license: true,
+      resources_documentation: true,
+      score: 0.9,
+      spatial: true,
+      temporal_coverage: true,
+      update_frequency: true,
+      update_fulfilled_in_time: true,
+    },
+    showItemWarnings: false,
+  }
 };

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/QualityComponent/QualityComponent.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/QualityComponent/QualityComponent.vue
@@ -1,113 +1,120 @@
 <template>
-    <div class="fr-grid-row fr-grid-row--middle fr-ml-n1v">
-    <Toggletip
-        class="fr-btn fr-btn--tertiary-no-outline fr-btn--secondary-grey-500 fr-icon-info-line"
-    >
-        {{$t('Metadata quality:')}}
-        <template #toggletip>
-            <h5 class="fr-text--sm fr-my-0">{{$t("Metadata quality:")}}</h5>
-            <QualityItem
-                :passed="quality.dataset_description_quality"
-                :messagePassed='$t("Data description filled")'
-                :messageFailed='$t("Data description empty")'
-                class="fr-my-1w"
-            />
-            <QualityItem
-                :passed="quality.resources_documentation"
-                :messagePassed='$t("Files documented")'
-                :messageFailed='$t("Files documentation missing")'
-                class="fr-my-1w"
-            />
-            <QualityItem
-                :passed="quality.license"
-                :messagePassed='$t("License filled")'
-                :messageFailed='$t("No license set")'
-                class="fr-my-1w"
-            />
-            <QualityItem
-                :passed="quality.update_frequency && !!quality.update_fulfilled_in_time"
-                :messagePassed='$t("Update frequency followed")'
-                :messageFailed='quality.update_frequency ? $t("Update frequency not followed") : $t("Update frequency not set")'
-                class="fr-my-1w"
-            />
-            <QualityItem
-                :passed="quality.has_open_format"
-                :messagePassed='$t("File formats are open")'
-                :messageFailed='$t("File formats are closed")'
-                class="fr-my-1w"
-            />
-            <QualityItem
-                :passed="quality.temporal_coverage"
-                :messagePassed='$t("Temporal coverage filled")'
-                :messageFailed='$t("Temporal coverage not set")'
-                class="fr-my-1w"
-            />
-            <QualityItem
-                :passed="quality.spatial"
-                :messagePassed='$t("Spatial coverage filled")'
-                :messageFailed='$t("Spatial coverage not set")'
-                class="fr-my-1w"
-            />
-            <QualityItem
-                :passed="quality.all_resources_available"
-                :messagePassed='$t("All files are available")'
-                :messageFailed='$t("Some files are unavailable")'
-                class="fr-my-1w"
-            />
-            <div class="fr-grid-row fr-grid-row--right not-enlarged">
-                <a
-                :href="config.guides_quality_url"
-                target="_blank"
-                rel="noopener"
-                :title="$t('Learn more about this indicator - opens a new window')"
-                >
-                {{$t("Learn more about this indicator")}}
-                </a>
-            </div>
-        </template>
-    </Toggletip>
-    <p class="fr-m-0 fr-mr-1v">
-        {{$t('Metadata quality:')}}
-    </p>
-    </div>
-    <QualityScore
-        :score="quality.score"
-        class="w-100"
+  <div class="fr-grid-row fr-grid-row--middle fr-ml-n1v">
+  <Toggletip
+    class="fr-btn fr-btn--tertiary-no-outline fr-btn--secondary-grey-500 fr-icon-info-line"
+  >
+    {{$t('Metadata quality:')}}
+    <template #toggletip>
+        <h5 class="fr-text--sm fr-my-0">{{$t("Metadata quality:")}}</h5>
+        <QualityItem
+            :passed="quality.dataset_description_quality"
+            :messagePassed='$t("Data description filled")'
+            :messageFailed='$t("Data description empty")'
+            class="fr-my-1w"
+        />
+        <QualityItem
+            :passed="quality.resources_documentation"
+            :messagePassed='$t("Files documented")'
+            :messageFailed='$t("Files documentation missing")'
+            class="fr-my-1w"
+        />
+        <QualityItem
+            :passed="quality.license"
+            :messagePassed='$t("License filled")'
+            :messageFailed='$t("No license set")'
+            class="fr-my-1w"
+        />
+        <QualityItem
+            :passed="quality.update_frequency && !!quality.update_fulfilled_in_time"
+            :messagePassed='$t("Update frequency followed")'
+            :messageFailed='quality.update_frequency ? $t("Update frequency not followed") : $t("Update frequency not set")'
+            class="fr-my-1w"
+        />
+        <QualityItem
+            :passed="quality.has_open_format"
+            :messagePassed='$t("File formats are open")'
+            :messageFailed='$t("File formats are closed")'
+            class="fr-my-1w"
+        />
+        <QualityItem
+            :passed="quality.temporal_coverage"
+            :messagePassed='$t("Temporal coverage filled")'
+            :messageFailed='$t("Temporal coverage not set")'
+            class="fr-my-1w"
+        />
+        <QualityItem
+            :passed="quality.spatial"
+            :messagePassed='$t("Spatial coverage filled")'
+            :messageFailed='$t("Spatial coverage not set")'
+            class="fr-my-1w"
+        />
+        <QualityItem
+            :passed="quality.all_resources_available"
+            :messagePassed='$t("All files are available")'
+            :messageFailed='$t("Some files are unavailable")'
+            class="fr-my-1w"
+        />
+        <div class="fr-grid-row fr-grid-row--right not-enlarged">
+            <a
+            :href="config.guides_quality_url"
+            target="_blank"
+            rel="noopener"
+            :title="$t('Learn more about this indicator - opens a new window')"
+            >
+            {{$t("Learn more about this indicator")}}
+            </a>
+        </div>
+    </template>
+  </Toggletip>
+  <p class="fr-m-0 fr-mr-1v">
+    {{$t('Metadata quality:')}}
+  </p>
+  </div>
+  <QualityScore
+    :score="quality.score"
+    class="w-100"
+  />
+  <template v-if="showItemWarnings">
+    <QualityItemWarning
+      :quality-item="quality.dataset_description_quality"
+      :message="$t('Data description empty')"
     />
-    <QualityItemWarning 
-        :quality-item="quality.dataset_description_quality"
-        :message="$t('Data description empty')"
+    <QualityItemWarning
+      :quality-item="quality.resources_documentation"
+      :message="$t('Files documentation missing')"
     />
-    <QualityItemWarning 
-        :quality-item="quality.resources_documentation"
-        :message="$t('Files documentation missing')"
+    <QualityItemWarning
+      :quality-item="quality.license"
+      :message="$t('No license set')"
     />
-    <QualityItemWarning 
-        :quality-item="quality.license"
-        :message="$t('No license set')"
+    <QualityItemWarning
+      :quality-item="quality.update_frequency && quality.update_fulfilled_in_time"
+      :message="quality.update_frequency ? $t('Update frequency not followed') : $t('Update frequency not set')"
     />
-    <QualityItemWarning 
-        :quality-item="quality.update_frequency && quality.update_fulfilled_in_time"
-        :message="quality.update_frequency ? $t('Update frequency not followed') : $t('Update frequency not set')"
+    <QualityItemWarning
+      :quality-item="quality.has_open_format"
+      :message="$t('File formats are closed')"
     />
-    <QualityItemWarning 
-        :quality-item="quality.has_open_format"
-        :message="$t('File formats are closed')"
+    <QualityItemWarning
+      :quality-item="quality.temporal_coverage"
+      :message="$t('Temporal coverage not set')"
     />
-    <QualityItemWarning 
-        :quality-item="quality.temporal_coverage"
-        :message="$t('Temporal coverage not set')"
+    <QualityItemWarning
+      :quality-item="quality.spatial"
+      :message="$t('Spatial coverage not set')"
     />
-    <QualityItemWarning 
-        :quality-item="quality.spatial"
-        :message="$t('Spatial coverage not set')"
+    <QualityItemWarning
+      :quality-item="quality.all_resources_available"
+      :message="$t('Some files are unavailable')"
     />
-    <QualityItemWarning 
-        :quality-item="quality.all_resources_available"
-        :message="$t('Some files are unavailable')"
-    />
+  </template>
 </template>
-
+<script lang="ts">
+export type QualityComponentProps = {
+  quality: Quality;
+  showItemWarnings?: boolean;
+};
+</script>
 <script setup lang="ts">
 import { QualityScore}  from '../QualityScore/';
 import { QualityItem } from '../QualityItem/';
@@ -115,7 +122,7 @@ import { QualityItemWarning } from '../QualityItemWarning/';
 import { Toggletip } from '../Toggletip/';
 import { config } from '../../config';
 import type { Quality } from '../../types/datasets';
-defineProps<{
-    quality: Quality
-}>();
+withDefaults(defineProps<QualityComponentProps>(), {
+  showItemWarnings: true,
+});
 </script>

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/QualityComponent/index.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/QualityComponent/index.ts
@@ -1,2 +1,5 @@
+import "../base.less";
+import "../button.less";
+import "../quality-score.less";
 import QualityComponent from "./QualityComponent.vue";
 export { QualityComponent };


### PR DESCRIPTION
This PR updates the non-inline version of the quality component in `@datagouv/components`. It's only used in udata-front-kit. In udata-front, we are only using the jinja version.

This update allows the component to be shown without the quality score warnings. It's required to make the same functionality as our jinja component (see https://github.com/ecolabdata/ecospheres/issues/187).