### PR TITLE
Use roadmap page instead of deprecated nouveautes in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix dataset card link opening another tab [#426](https://github.com/datagouv/udata-front/pull/426)
+- Use roadmap page instead of deprecated nouveautes in footer [#429](https://github.com/datagouv/udata-front/pull/429)
 
 ## 5.0.0 (2024-06-07)
 

--- a/udata_front/theme/gouvfr/__init__.py
+++ b/udata_front/theme/gouvfr/__init__.py
@@ -99,7 +99,7 @@ nav.Bar('gouvfr_opendata', opendata_links)
 
 platform_links = [
     nav.Item(_('Guides'), None, url=current_app.config.get('GUIDES_URL', '#')),
-    nav.Item(_('Roadmap and news'), 'gouvfr.show_page', args={'slug': 'nouveautes'}),
+    nav.Item(_('Roadmap and news'), 'gouvfr.show_page', args={'slug': 'roadmap'}),
     nav.Item(_('Contact us'), None, url='https://support.data.gouv.fr'),
     nav.Item(_('Give us your feedback'), None,
              url=current_app.config.get('FEEDBACK_FORM_URL', '#')),


### PR DESCRIPTION
Noticed by @agarrone 