### PR TITLE
Activate chromatic turbosnap

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook",
-    "chromatic": "npx chromatic"
+    "chromatic": "npx chromatic --only-changed"
   },
   "overrides": {
     "fsevents": "^2.3.3"


### PR DESCRIPTION
This PR activate [TurboSnap](https://www.chromatic.com/docs/turbosnap/) to reduce Chromatic usage and time required for the build by doing visual snapshots only on files changed, using webpack dependency graph.

Example of output :

```
Chromatic CLI v11.5.3
https://www.chromatic.com/docs/cli

  ✔ Authenticated with Chromatic
    → Using project token 
  ✔ Skipping build
    → Skipping rebuild of an already fully passed/accepted build
  ↓ Collect Storybook metadata [skipped]
  ↓ Initialize build [skipped]
  ↓ Build Storybook [skipped]
  ↓ Publish your built Storybook [skipped]
  ↓ Verify your Storybook [skipped]
  ↓ Test your stories [skipped]

ℹ Skipping rebuild of an already fully passed/accepted build
A build for the same commit as the last build on the branch is considered a rebuild.
If the last build is passed or accepted, the rebuild is skipped because it shouldn't change anything.
You can override this using the --force-rebuild flag.
```