### PR TITLE
Fix tests for oembed cors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add beta admin "add member" modale [#442](https://github.com/etalab/udata-front/pull/442)
 - Update dependencies from udata [#448](https://github.com/datagouv/udata-front/pull/448)
 - Add new dataset card [#445](https://github.com/datagouv/udata-front/pull/445)
+- Fix tests for oembed CORS [#453](https://github.com/datagouv/udata-front/pull/453)
 
 ## 5.0.1 (2024-06-12)
 

--- a/udata_front/tests/views/test_oembed.py
+++ b/udata_front/tests/views/test_oembed.py
@@ -31,7 +31,7 @@ class OEmbedAPITest:
 
         url = url_for('api.oembed', url=dataset.external_url)
 
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert200(response)
         assert_cors(response)
         assert 'html' in response.json
@@ -51,7 +51,7 @@ class OEmbedAPITest:
 
         url = url_for('api.oembed', url=dataset.external_url)
 
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert200(response)
         assert_cors(response)
 
@@ -65,7 +65,7 @@ class OEmbedAPITest:
                                dataset=dataset, _external=True)
 
         url = url_for('api.oembed', url=redirect_url)
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert200(response)
         assert_cors(response)
         assert 'html' in response.json
@@ -83,7 +83,7 @@ class OEmbedAPITest:
         dataset_url = url_for('datasets.show', dataset='unknown',
                               _external=True)
         url = url_for('api.oembed', url=dataset_url)
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert404(response)
         assert_cors(response)
 
@@ -92,7 +92,7 @@ class OEmbedAPITest:
         reuse = ReuseFactory()
 
         url = url_for('api.oembed', url=reuse.external_url)
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert200(response)
         assert_cors(response)
         assert 'html' in response.json
@@ -110,7 +110,7 @@ class OEmbedAPITest:
         org = OrganizationFactory()
 
         url = url_for('api.oembed', url=org.external_url)
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert200(response)
         assert_cors(response)
         assert 'html' in response.json
@@ -138,7 +138,7 @@ class OEmbedAPITest:
     def test_oembed_with_an_unknown_url(self, api):
         '''It should fail at fetching an oembed with an invalid URL.'''
         url = url_for('api.oembed', url='http://local.test/somewhere')
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert404(response)
         assert_cors(response)
 
@@ -155,7 +155,7 @@ class OEmbedAPITest:
         '''It does not support xml format.'''
         dataset = DatasetFactory()
         url = url_for('api.oembed', url=dataset.external_url, format='xml')
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert_status(response, 501)
         assert_cors(response)
         assert response.json['message'] == 'Only JSON format is supported'
@@ -202,7 +202,7 @@ class OEmbedsDatasetAPITest:
 
         url = url_for('api.oembeds',
                       references='dataset-{id}'.format(id=dataset.id))
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert200(response)
         data = response.json[0]
         assert 'html' in data
@@ -224,7 +224,7 @@ class OEmbedsDatasetAPITest:
 
         url = url_for('api.oembeds',
                       references='dataset-{id}'.format(id=dataset.id))
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert200(response)
         data = response.json[0]
         assert organization.name in data['html']
@@ -247,14 +247,14 @@ class OEmbedsDatasetAPITest:
         user = UserFactory()
 
         url = url_for('api.oembeds', references='user-{id}'.format(id=user.id))
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert400(response)
         assert response.json['message'] == 'Invalid object type.'
 
     def test_oembeds_dataset_api_get_without_valid_id(self, api):
         '''It should fail at fetching an oembed without a valid id.'''
         url = url_for('api.oembeds', references='dataset-123456789')
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert400(response)
         assert response.json['message'] == 'Unknown dataset ID.'
 
@@ -267,7 +267,7 @@ class OEmbedsDatasetAPITest:
         TERRITORY_DATASETS[level][TestDataset.id] = TestDataset
         reference = 'territory-{0}:{1}'.format(zone.id, TestDataset.id)
         url = url_for('api.oembeds', references=reference)
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert200(response)
         data = response.json[0]
         assert 'html' in data
@@ -291,7 +291,7 @@ class OEmbedsDatasetAPITest:
         reference = 'territory-{0}:{1}'.format(geoid, TestDataset.id)
 
         url = url_for('api.oembeds', references=reference)
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert200(response)
         data = response.json[0]
         assert 'html' in data
@@ -307,7 +307,7 @@ class OEmbedsDatasetAPITest:
     def test_oembeds_api_for_territory_bad_id(self, api):
         '''Should raise 400 on bad territory ID'''
         url = url_for('api.oembeds', references='territory-xyz')
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert400(response)
         assert response.json['message'] == 'Invalid territory ID.'
 
@@ -315,7 +315,7 @@ class OEmbedsDatasetAPITest:
         '''Should raise 400 on unknown zone ID'''
         url = url_for('api.oembeds',
                       references='territory-fr:commune:13004@1970-01-01:xyz')
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert400(response)
         assert response.json['message'] == 'Unknown territory identifier.'
 
@@ -328,7 +328,7 @@ class OEmbedsDatasetAPITest:
         del TERRITORY_DATASETS[level]
         reference = 'territory-{0}:{1}'.format(zone.id, TestDataset.id)
         url = url_for('api.oembeds', references=reference)
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert400(response)
         assert response.json['message'] == 'Unknown kind of territory.'
 
@@ -341,6 +341,6 @@ class OEmbedsDatasetAPITest:
         TERRITORY_DATASETS[level] = {}
         reference = 'territory-{0}:{1}'.format(zone.id, TestDataset.id)
         url = url_for('api.oembeds', references=reference)
-        response = api.get(url)
+        response = api.get(url, headers={ 'Origin': 'http://localhost' })
         assert400(response)
         assert response.json['message'] == 'Unknown territory dataset id.'

--- a/udata_front/tests/views/test_oembed.py
+++ b/udata_front/tests/views/test_oembed.py
@@ -9,13 +9,17 @@ from udata.core.reuse.factories import ReuseFactory
 from udata.core.spatial.factories import GeoZoneFactory
 from udata.core.user.factories import UserFactory
 from udata.core.organization.factories import OrganizationFactory
-from udata.features.territories.models import (
-    TerritoryDataset, TERRITORY_DATASETS
-)
+from udata.features.territories.models import TerritoryDataset, TERRITORY_DATASETS
 
 from udata.settings import Testing
 from udata.utils import faker
-from udata.tests.helpers import assert200, assert400, assert404, assert_status, assert_cors
+from udata.tests.helpers import (
+    assert200,
+    assert400,
+    assert404,
+    assert_status,
+    assert_cors,
+)
 from udata.frontend.markdown import mdstrip
 
 from udata_front.tests import GouvFrSettings
@@ -26,139 +30,164 @@ class OEmbedAPITest:
     modules = []
 
     def test_oembed_for_dataset(self, api):
-        '''It should fetch a dataset in the oembed format.'''
+        """It should fetch a dataset in the oembed format."""
         dataset = DatasetFactory()
 
-        url = url_for('api.oembed', url=dataset.external_url)
+        url = url_for("api.oembed", url=dataset.external_url)
 
-        response = api.get(url)
+        response = api.get(
+            url,
+            headers={"Origin": "http://localhost"},
+        )
         assert200(response)
         assert_cors(response)
-        assert 'html' in response.json
-        assert 'width' in response.json
-        assert 'maxwidth' in response.json
-        assert 'height' in response.json
-        assert 'maxheight' in response.json
-        assert response.json['type'] == 'rich'
-        assert response.json['version'] == '1.0'
-        card = theme.render('dataset/card-xs.html', dataset=dataset)
-        assert card in response.json['html']
+        assert "html" in response.json
+        assert "width" in response.json
+        assert "maxwidth" in response.json
+        assert "height" in response.json
+        assert "maxheight" in response.json
+        assert response.json["type"] == "rich"
+        assert response.json["version"] == "1.0"
+        card = theme.render("dataset/card-xs.html", dataset=dataset)
+        assert card in response.json["html"]
 
     def test_oembed_for_dataset_with_organization(self, api):
-        '''It should fetch a dataset in the oembed format with org.'''
+        """It should fetch a dataset in the oembed format with org."""
         organization = OrganizationFactory()
         dataset = DatasetFactory(organization=organization)
 
-        url = url_for('api.oembed', url=dataset.external_url)
+        url = url_for("api.oembed", url=dataset.external_url)
 
-        response = api.get(url)
+        response = api.get(
+            url,
+            headers={"Origin": "http://localhost"},
+        )
         assert200(response)
         assert_cors(response)
 
-        card = theme.render('dataset/card-xs.html', dataset=dataset)
-        assert card in response.json['html']
+        card = theme.render("dataset/card-xs.html", dataset=dataset)
+        assert card in response.json["html"]
 
     def test_oembed_for_dataset_redirect_link(self, api):
-        '''It should fetch an oembed dataset using the redirect link.'''
+        """It should fetch an oembed dataset using the redirect link."""
         dataset = DatasetFactory()
-        redirect_url = url_for('datasets.show_redirect',
-                               dataset=dataset, _external=True)
+        redirect_url = url_for(
+            "datasets.show_redirect", dataset=dataset, _external=True
+        )
 
-        url = url_for('api.oembed', url=redirect_url)
-        response = api.get(url)
+        url = url_for("api.oembed", url=redirect_url)
+        response = api.get(
+            url,
+            headers={"Origin": "http://localhost"},
+        )
         assert200(response)
         assert_cors(response)
-        assert 'html' in response.json
-        assert 'width' in response.json
-        assert 'maxwidth' in response.json
-        assert 'height' in response.json
-        assert 'maxheight' in response.json
-        assert response.json['type'] == 'rich'
-        assert response.json['version'] == '1.0'
-        card = theme.render('dataset/card-xs.html', dataset=dataset)
-        assert card in response.json['html']
+        assert "html" in response.json
+        assert "width" in response.json
+        assert "maxwidth" in response.json
+        assert "height" in response.json
+        assert "maxheight" in response.json
+        assert response.json["type"] == "rich"
+        assert response.json["version"] == "1.0"
+        card = theme.render("dataset/card-xs.html", dataset=dataset)
+        assert card in response.json["html"]
 
     def test_oembed_for_unknown_dataset(self, api):
-        '''It should raise a 404 on missing dataset.'''
-        dataset_url = url_for('datasets.show', dataset='unknown',
-                              _external=True)
-        url = url_for('api.oembed', url=dataset_url)
-        response = api.get(url)
+        """It should raise a 404 on missing dataset."""
+        dataset_url = url_for("datasets.show", dataset="unknown", _external=True)
+        url = url_for("api.oembed", url=dataset_url)
+        response = api.get(
+            url,
+            headers={"Origin": "http://localhost"},
+        )
         assert404(response)
         assert_cors(response)
 
     def test_oembed_for_reuse(self, api):
-        '''It should fetch a reuse in the oembed format.'''
+        """It should fetch a reuse in the oembed format."""
         reuse = ReuseFactory()
 
-        url = url_for('api.oembed', url=reuse.external_url)
-        response = api.get(url)
+        url = url_for("api.oembed", url=reuse.external_url)
+        response = api.get(
+            url,
+            headers={"Origin": "http://localhost"},
+        )
         assert200(response)
         assert_cors(response)
-        assert 'html' in response.json
-        assert 'width' in response.json
-        assert 'maxwidth' in response.json
-        assert 'height' in response.json
-        assert 'maxheight' in response.json
-        assert response.json['type'] == 'rich'
-        assert response.json['version'] == '1.0'
-        card = theme.render('reuse/card.html', reuse=reuse)
-        assert card in response.json['html']
+        assert "html" in response.json
+        assert "width" in response.json
+        assert "maxwidth" in response.json
+        assert "height" in response.json
+        assert "maxheight" in response.json
+        assert response.json["type"] == "rich"
+        assert response.json["version"] == "1.0"
+        card = theme.render("reuse/card.html", reuse=reuse)
+        assert card in response.json["html"]
 
     def test_oembed_for_org(self, api):
-        '''It should fetch an organization in the oembed format.'''
+        """It should fetch an organization in the oembed format."""
         org = OrganizationFactory()
 
-        url = url_for('api.oembed', url=org.external_url)
-        response = api.get(url)
+        url = url_for("api.oembed", url=org.external_url)
+        response = api.get(
+            url,
+            headers={"Origin": "http://localhost"},
+        )
         assert200(response)
         assert_cors(response)
-        assert 'html' in response.json
-        assert 'width' in response.json
-        assert 'maxwidth' in response.json
-        assert 'height' in response.json
-        assert 'maxheight' in response.json
-        assert response.json['type'] == 'rich'
-        assert response.json['version'] == '1.0'
-        card = theme.render('organization/card.html', organization=org)
-        assert card in response.json['html']
+        assert "html" in response.json
+        assert "width" in response.json
+        assert "maxwidth" in response.json
+        assert "height" in response.json
+        assert "maxheight" in response.json
+        assert response.json["type"] == "rich"
+        assert response.json["version"] == "1.0"
+        card = theme.render("organization/card.html", organization=org)
+        assert card in response.json["html"]
 
     def test_oembed_without_url(self, api):
-        '''It should fail at fetching an oembed without a dataset.'''
-        response = api.get(url_for('api.oembed'))
+        """It should fail at fetching an oembed without a dataset."""
+        response = api.get(url_for("api.oembed"))
         assert400(response)
-        assert 'url' in response.json['errors']
+        assert "url" in response.json["errors"]
 
     def test_oembed_with_an_invalid_url(self, api):
-        '''It should fail at fetching an oembed with an invalid URL.'''
-        response = api.get(url_for('api.oembed', url='123456789'))
+        """It should fail at fetching an oembed with an invalid URL."""
+        response = api.get(url_for("api.oembed", url="123456789"))
         assert400(response)
-        assert 'url' in response.json['errors']
+        assert "url" in response.json["errors"]
 
     def test_oembed_with_an_unknown_url(self, api):
-        '''It should fail at fetching an oembed with an invalid URL.'''
-        url = url_for('api.oembed', url='http://local.test/somewhere')
-        response = api.get(url)
+        """It should fail at fetching an oembed with an invalid URL."""
+        url = url_for("api.oembed", url="http://local.test/somewhere")
+        response = api.get(
+            url,
+            headers={"Origin": "http://localhost"},
+        )
         assert404(response)
         assert_cors(response)
 
     def test_oembed_with_port_in_https_url(self, api):
-        '''It should works on HTTPS URLs with explicit port.'''
+        """It should works on HTTPS URLs with explicit port."""
         dataset = DatasetFactory()
-        url = dataset.external_url.replace('http://local.test/',
-                                           'https://local.test:443/')
-        api_url = url_for('api.oembed', url=url)
+        url = dataset.external_url.replace(
+            "http://local.test/", "https://local.test:443/"
+        )
+        api_url = url_for("api.oembed", url=url)
 
-        assert200(api.get(api_url, base_url='https://local.test:443/'))
+        assert200(api.get(api_url, base_url="https://local.test:443/"))
 
     def test_oembed_does_not_support_xml(self, api):
-        '''It does not support xml format.'''
+        """It does not support xml format."""
         dataset = DatasetFactory()
-        url = url_for('api.oembed', url=dataset.external_url, format='xml')
-        response = api.get(url)
+        url = url_for("api.oembed", url=dataset.external_url, format="xml")
+        response = api.get(
+            url,
+            headers={"Origin": "http://localhost"},
+        )
         assert_status(response, 501)
         assert_cors(response)
-        assert response.json['message'] == 'Only JSON format is supported'
+        assert response.json["message"] == "Only JSON format is supported"
 
 
 def territory_dataset_factory():
@@ -170,8 +199,8 @@ def territory_dataset_factory():
         title = faker.sentence()
         organization_id = str(org.id)
         description = faker.paragraph()
-        temporal_coverage = {'start': 2007, 'end': 2012}
-        url_template = 'http://somehere.com/{code}'
+        temporal_coverage = {"start": 2007, "end": 2012}
+        url_template = "http://somehere.com/{code}"
 
     return TestDataset
 
@@ -180,8 +209,8 @@ class OEmbedSettings(Testing):
     ACTIVATE_TERRITORIES = True
     TEST_WITH_THEME = True
     TEST_WITH_PLUGINS = True
-    PLUGINS = ['front']
-    THEME = 'gouvfr'
+    PLUGINS = ["front"]
+    THEME = "gouvfr"
 
 
 class OEmbedsDatasetAPITest:
@@ -197,150 +226,149 @@ class OEmbedsDatasetAPITest:
         TERRITORY_DATASETS.update(self.territory_datasets_backup)
 
     def test_oembeds_dataset_api_get(self, api):
-        '''It should fetch a dataset in the oembed format.'''
+        """It should fetch a dataset in the oembed format."""
         dataset = DatasetFactory()
 
-        url = url_for('api.oembeds',
-                      references='dataset-{id}'.format(id=dataset.id))
+        url = url_for("api.oembeds", references="dataset-{id}".format(id=dataset.id))
         response = api.get(url)
         assert200(response)
         data = response.json[0]
-        assert 'html' in data
-        assert 'width' in data
-        assert 'maxwidth' in data
-        assert 'height' in data
-        assert 'maxheight' in data
-        assert data['type'] == 'rich'
-        assert data['version'] == '1.0'
-        assert dataset.title in data['html']
-        assert dataset.external_url in data['html']
-        assert 'placeholders/default.png' in data['html']
-        assert mdstrip(dataset.description, 110) in data['html']
+        assert "html" in data
+        assert "width" in data
+        assert "maxwidth" in data
+        assert "height" in data
+        assert "maxheight" in data
+        assert data["type"] == "rich"
+        assert data["version"] == "1.0"
+        assert dataset.title in data["html"]
+        assert dataset.external_url in data["html"]
+        assert "placeholders/default.png" in data["html"]
+        assert mdstrip(dataset.description, 110) in data["html"]
 
     def test_oembeds_dataset_api_get_with_organization(self, api):
-        '''It should fetch a dataset in the oembed format with org.'''
+        """It should fetch a dataset in the oembed format with org."""
         organization = OrganizationFactory()
         dataset = DatasetFactory(organization=organization)
 
-        url = url_for('api.oembeds',
-                      references='dataset-{id}'.format(id=dataset.id))
+        url = url_for("api.oembeds", references="dataset-{id}".format(id=dataset.id))
         response = api.get(url)
         assert200(response)
         data = response.json[0]
-        assert organization.name in data['html']
-        assert organization.external_url in data['html']
+        assert organization.name in data["html"]
+        assert organization.external_url in data["html"]
 
     def test_oembeds_dataset_api_get_without_references(self, api):
-        '''It should fail at fetching an oembed without a dataset.'''
-        response = api.get(url_for('api.oembeds'))
+        """It should fail at fetching an oembed without a dataset."""
+        response = api.get(url_for("api.oembeds"))
         assert400(response)
-        assert 'references' in response.json['errors']
+        assert "references" in response.json["errors"]
 
     def test_oembeds_dataset_api_get_without_good_id(self, api):
-        '''It should fail at fetching an oembed without a good id.'''
-        response = api.get(url_for('api.oembeds', references='123456789'))
+        """It should fail at fetching an oembed without a good id."""
+        response = api.get(url_for("api.oembeds", references="123456789"))
         assert400(response)
-        assert response.json['message'] == 'Invalid ID.'
+        assert response.json["message"] == "Invalid ID."
 
     def test_oembeds_dataset_api_get_without_good_item(self, api):
-        '''It should fail at fetching an oembed with a wrong item.'''
+        """It should fail at fetching an oembed with a wrong item."""
         user = UserFactory()
 
-        url = url_for('api.oembeds', references='user-{id}'.format(id=user.id))
+        url = url_for("api.oembeds", references="user-{id}".format(id=user.id))
         response = api.get(url)
         assert400(response)
-        assert response.json['message'] == 'Invalid object type.'
+        assert response.json["message"] == "Invalid object type."
 
     def test_oembeds_dataset_api_get_without_valid_id(self, api):
-        '''It should fail at fetching an oembed without a valid id.'''
-        url = url_for('api.oembeds', references='dataset-123456789')
+        """It should fail at fetching an oembed without a valid id."""
+        url = url_for("api.oembeds", references="dataset-123456789")
         response = api.get(url)
         assert400(response)
-        assert response.json['message'] == 'Unknown dataset ID.'
+        assert response.json["message"] == "Unknown dataset ID."
 
     def test_oembeds_api_for_territory(self, api):
-        '''It should fetch a territory in the oembed format.'''
+        """It should fetch a territory in the oembed format."""
         country = faker.country_code().lower()
-        level = 'commune'
-        zone = GeoZoneFactory(level='{0}:{1}'.format(country, level))
+        level = "commune"
+        zone = GeoZoneFactory(level="{0}:{1}".format(country, level))
         TestDataset = territory_dataset_factory()
         TERRITORY_DATASETS[level][TestDataset.id] = TestDataset
-        reference = 'territory-{0}:{1}'.format(zone.id, TestDataset.id)
-        url = url_for('api.oembeds', references=reference)
+        reference = "territory-{0}:{1}".format(zone.id, TestDataset.id)
+        url = url_for("api.oembeds", references=reference)
         response = api.get(url)
         assert200(response)
         data = response.json[0]
-        assert 'html' in data
-        assert 'width' in data
-        assert 'maxwidth' in data
-        assert 'height' in data
-        assert 'maxheight' in data
-        assert data['type'] == 'rich'
-        assert data['version'] == '1.0'
-        assert zone.name in data['html']
-        assert 'placeholders/default.png' in data['html']
+        assert "html" in data
+        assert "width" in data
+        assert "maxwidth" in data
+        assert "height" in data
+        assert "maxheight" in data
+        assert data["type"] == "rich"
+        assert data["version"] == "1.0"
+        assert zone.name in data["html"]
+        assert "placeholders/default.png" in data["html"]
 
     def test_oembeds_api_for_territory_resolve_geoid(self, api):
-        '''It should fetch a territory from a geoid in the oembed format.'''
+        """It should fetch a territory from a geoid in the oembed format."""
         country = faker.country_code().lower()
-        level = 'commune'
-        zone = GeoZoneFactory(level='{0}:{1}'.format(country, level))
+        level = "commune"
+        zone = GeoZoneFactory(level="{0}:{1}".format(country, level))
         TestDataset = territory_dataset_factory()
         TERRITORY_DATASETS[level][TestDataset.id] = TestDataset
-        geoid = '{0.level}:{0.code}@latest'.format(zone)
-        reference = 'territory-{0}:{1}'.format(geoid, TestDataset.id)
+        geoid = "{0.level}:{0.code}@latest".format(zone)
+        reference = "territory-{0}:{1}".format(geoid, TestDataset.id)
 
-        url = url_for('api.oembeds', references=reference)
+        url = url_for("api.oembeds", references=reference)
         response = api.get(url)
         assert200(response)
         data = response.json[0]
-        assert 'html' in data
-        assert 'width' in data
-        assert 'maxwidth' in data
-        assert 'height' in data
-        assert 'maxheight' in data
-        assert data['type'] == 'rich'
-        assert data['version'] == '1.0'
-        assert zone.name in data['html']
-        assert 'placeholders/default.png' in data['html']
+        assert "html" in data
+        assert "width" in data
+        assert "maxwidth" in data
+        assert "height" in data
+        assert "maxheight" in data
+        assert data["type"] == "rich"
+        assert data["version"] == "1.0"
+        assert zone.name in data["html"]
+        assert "placeholders/default.png" in data["html"]
 
     def test_oembeds_api_for_territory_bad_id(self, api):
-        '''Should raise 400 on bad territory ID'''
-        url = url_for('api.oembeds', references='territory-xyz')
+        """Should raise 400 on bad territory ID"""
+        url = url_for("api.oembeds", references="territory-xyz")
         response = api.get(url)
         assert400(response)
-        assert response.json['message'] == 'Invalid territory ID.'
+        assert response.json["message"] == "Invalid territory ID."
 
     def test_oembeds_api_for_territory_zone_not_found(self, api):
-        '''Should raise 400 on unknown zone ID'''
-        url = url_for('api.oembeds',
-                      references='territory-fr:commune:13004@1970-01-01:xyz')
+        """Should raise 400 on unknown zone ID"""
+        url = url_for(
+            "api.oembeds", references="territory-fr:commune:13004@1970-01-01:xyz"
+        )
         response = api.get(url)
         assert400(response)
-        assert response.json['message'] == 'Unknown territory identifier.'
+        assert response.json["message"] == "Unknown territory identifier."
 
     def test_oembeds_api_for_territory_level_not_registered(self, api):
-        '''Should raise 400 on unregistered territory level'''
+        """Should raise 400 on unregistered territory level"""
         country = faker.country_code().lower()
-        level = 'commune'
-        zone = GeoZoneFactory(level='{0}:{1}'.format(country, level))
+        level = "commune"
+        zone = GeoZoneFactory(level="{0}:{1}".format(country, level))
         TestDataset = territory_dataset_factory()
         del TERRITORY_DATASETS[level]
-        reference = 'territory-{0}:{1}'.format(zone.id, TestDataset.id)
-        url = url_for('api.oembeds', references=reference)
+        reference = "territory-{0}:{1}".format(zone.id, TestDataset.id)
+        url = url_for("api.oembeds", references=reference)
         response = api.get(url)
         assert400(response)
-        assert response.json['message'] == 'Unknown kind of territory.'
+        assert response.json["message"] == "Unknown kind of territory."
 
     def test_oembeds_api_for_territory_dataset_not_registered(self, api):
-        '''Should raise 400 on unregistered territory dataset'''
+        """Should raise 400 on unregistered territory dataset"""
         country = faker.country_code().lower()
-        level = 'commune'
-        zone = GeoZoneFactory(level='{0}:{1}'.format(country, level))
+        level = "commune"
+        zone = GeoZoneFactory(level="{0}:{1}".format(country, level))
         TestDataset = territory_dataset_factory()
         TERRITORY_DATASETS[level] = {}
-        reference = 'territory-{0}:{1}'.format(zone.id, TestDataset.id)
-        url = url_for('api.oembeds', references=reference)
+        reference = "territory-{0}:{1}".format(zone.id, TestDataset.id)
+        url = url_for("api.oembeds", references=reference)
         response = api.get(url)
         assert400(response)
-        assert response.json['message'] == 'Unknown territory dataset id.'
+        assert response.json["message"] == "Unknown territory dataset id."

--- a/udata_front/tests/views/test_oembed.py
+++ b/udata_front/tests/views/test_oembed.py
@@ -9,17 +9,13 @@ from udata.core.reuse.factories import ReuseFactory
 from udata.core.spatial.factories import GeoZoneFactory
 from udata.core.user.factories import UserFactory
 from udata.core.organization.factories import OrganizationFactory
-from udata.features.territories.models import TerritoryDataset, TERRITORY_DATASETS
+from udata.features.territories.models import (
+    TerritoryDataset, TERRITORY_DATASETS
+)
 
 from udata.settings import Testing
 from udata.utils import faker
-from udata.tests.helpers import (
-    assert200,
-    assert400,
-    assert404,
-    assert_status,
-    assert_cors,
-)
+from udata.tests.helpers import assert200, assert400, assert404, assert_status, assert_cors
 from udata.frontend.markdown import mdstrip
 
 from udata_front.tests import GouvFrSettings
@@ -30,164 +26,139 @@ class OEmbedAPITest:
     modules = []
 
     def test_oembed_for_dataset(self, api):
-        """It should fetch a dataset in the oembed format."""
+        '''It should fetch a dataset in the oembed format.'''
         dataset = DatasetFactory()
 
-        url = url_for("api.oembed", url=dataset.external_url)
+        url = url_for('api.oembed', url=dataset.external_url)
 
-        response = api.get(
-            url,
-            headers={"Origin": "http://localhost"},
-        )
+        response = api.get(url)
         assert200(response)
         assert_cors(response)
-        assert "html" in response.json
-        assert "width" in response.json
-        assert "maxwidth" in response.json
-        assert "height" in response.json
-        assert "maxheight" in response.json
-        assert response.json["type"] == "rich"
-        assert response.json["version"] == "1.0"
-        card = theme.render("dataset/card-xs.html", dataset=dataset)
-        assert card in response.json["html"]
+        assert 'html' in response.json
+        assert 'width' in response.json
+        assert 'maxwidth' in response.json
+        assert 'height' in response.json
+        assert 'maxheight' in response.json
+        assert response.json['type'] == 'rich'
+        assert response.json['version'] == '1.0'
+        card = theme.render('dataset/card-xs.html', dataset=dataset)
+        assert card in response.json['html']
 
     def test_oembed_for_dataset_with_organization(self, api):
-        """It should fetch a dataset in the oembed format with org."""
+        '''It should fetch a dataset in the oembed format with org.'''
         organization = OrganizationFactory()
         dataset = DatasetFactory(organization=organization)
 
-        url = url_for("api.oembed", url=dataset.external_url)
+        url = url_for('api.oembed', url=dataset.external_url)
 
-        response = api.get(
-            url,
-            headers={"Origin": "http://localhost"},
-        )
+        response = api.get(url)
         assert200(response)
         assert_cors(response)
 
-        card = theme.render("dataset/card-xs.html", dataset=dataset)
-        assert card in response.json["html"]
+        card = theme.render('dataset/card-xs.html', dataset=dataset)
+        assert card in response.json['html']
 
     def test_oembed_for_dataset_redirect_link(self, api):
-        """It should fetch an oembed dataset using the redirect link."""
+        '''It should fetch an oembed dataset using the redirect link.'''
         dataset = DatasetFactory()
-        redirect_url = url_for(
-            "datasets.show_redirect", dataset=dataset, _external=True
-        )
+        redirect_url = url_for('datasets.show_redirect',
+                               dataset=dataset, _external=True)
 
-        url = url_for("api.oembed", url=redirect_url)
-        response = api.get(
-            url,
-            headers={"Origin": "http://localhost"},
-        )
+        url = url_for('api.oembed', url=redirect_url)
+        response = api.get(url)
         assert200(response)
         assert_cors(response)
-        assert "html" in response.json
-        assert "width" in response.json
-        assert "maxwidth" in response.json
-        assert "height" in response.json
-        assert "maxheight" in response.json
-        assert response.json["type"] == "rich"
-        assert response.json["version"] == "1.0"
-        card = theme.render("dataset/card-xs.html", dataset=dataset)
-        assert card in response.json["html"]
+        assert 'html' in response.json
+        assert 'width' in response.json
+        assert 'maxwidth' in response.json
+        assert 'height' in response.json
+        assert 'maxheight' in response.json
+        assert response.json['type'] == 'rich'
+        assert response.json['version'] == '1.0'
+        card = theme.render('dataset/card-xs.html', dataset=dataset)
+        assert card in response.json['html']
 
     def test_oembed_for_unknown_dataset(self, api):
-        """It should raise a 404 on missing dataset."""
-        dataset_url = url_for("datasets.show", dataset="unknown", _external=True)
-        url = url_for("api.oembed", url=dataset_url)
-        response = api.get(
-            url,
-            headers={"Origin": "http://localhost"},
-        )
+        '''It should raise a 404 on missing dataset.'''
+        dataset_url = url_for('datasets.show', dataset='unknown',
+                              _external=True)
+        url = url_for('api.oembed', url=dataset_url)
+        response = api.get(url)
         assert404(response)
         assert_cors(response)
 
     def test_oembed_for_reuse(self, api):
-        """It should fetch a reuse in the oembed format."""
+        '''It should fetch a reuse in the oembed format.'''
         reuse = ReuseFactory()
 
-        url = url_for("api.oembed", url=reuse.external_url)
-        response = api.get(
-            url,
-            headers={"Origin": "http://localhost"},
-        )
+        url = url_for('api.oembed', url=reuse.external_url)
+        response = api.get(url)
         assert200(response)
         assert_cors(response)
-        assert "html" in response.json
-        assert "width" in response.json
-        assert "maxwidth" in response.json
-        assert "height" in response.json
-        assert "maxheight" in response.json
-        assert response.json["type"] == "rich"
-        assert response.json["version"] == "1.0"
-        card = theme.render("reuse/card.html", reuse=reuse)
-        assert card in response.json["html"]
+        assert 'html' in response.json
+        assert 'width' in response.json
+        assert 'maxwidth' in response.json
+        assert 'height' in response.json
+        assert 'maxheight' in response.json
+        assert response.json['type'] == 'rich'
+        assert response.json['version'] == '1.0'
+        card = theme.render('reuse/card.html', reuse=reuse)
+        assert card in response.json['html']
 
     def test_oembed_for_org(self, api):
-        """It should fetch an organization in the oembed format."""
+        '''It should fetch an organization in the oembed format.'''
         org = OrganizationFactory()
 
-        url = url_for("api.oembed", url=org.external_url)
-        response = api.get(
-            url,
-            headers={"Origin": "http://localhost"},
-        )
+        url = url_for('api.oembed', url=org.external_url)
+        response = api.get(url)
         assert200(response)
         assert_cors(response)
-        assert "html" in response.json
-        assert "width" in response.json
-        assert "maxwidth" in response.json
-        assert "height" in response.json
-        assert "maxheight" in response.json
-        assert response.json["type"] == "rich"
-        assert response.json["version"] == "1.0"
-        card = theme.render("organization/card.html", organization=org)
-        assert card in response.json["html"]
+        assert 'html' in response.json
+        assert 'width' in response.json
+        assert 'maxwidth' in response.json
+        assert 'height' in response.json
+        assert 'maxheight' in response.json
+        assert response.json['type'] == 'rich'
+        assert response.json['version'] == '1.0'
+        card = theme.render('organization/card.html', organization=org)
+        assert card in response.json['html']
 
     def test_oembed_without_url(self, api):
-        """It should fail at fetching an oembed without a dataset."""
-        response = api.get(url_for("api.oembed"))
+        '''It should fail at fetching an oembed without a dataset.'''
+        response = api.get(url_for('api.oembed'))
         assert400(response)
-        assert "url" in response.json["errors"]
+        assert 'url' in response.json['errors']
 
     def test_oembed_with_an_invalid_url(self, api):
-        """It should fail at fetching an oembed with an invalid URL."""
-        response = api.get(url_for("api.oembed", url="123456789"))
+        '''It should fail at fetching an oembed with an invalid URL.'''
+        response = api.get(url_for('api.oembed', url='123456789'))
         assert400(response)
-        assert "url" in response.json["errors"]
+        assert 'url' in response.json['errors']
 
     def test_oembed_with_an_unknown_url(self, api):
-        """It should fail at fetching an oembed with an invalid URL."""
-        url = url_for("api.oembed", url="http://local.test/somewhere")
-        response = api.get(
-            url,
-            headers={"Origin": "http://localhost"},
-        )
+        '''It should fail at fetching an oembed with an invalid URL.'''
+        url = url_for('api.oembed', url='http://local.test/somewhere')
+        response = api.get(url)
         assert404(response)
         assert_cors(response)
 
     def test_oembed_with_port_in_https_url(self, api):
-        """It should works on HTTPS URLs with explicit port."""
+        '''It should works on HTTPS URLs with explicit port.'''
         dataset = DatasetFactory()
-        url = dataset.external_url.replace(
-            "http://local.test/", "https://local.test:443/"
-        )
-        api_url = url_for("api.oembed", url=url)
+        url = dataset.external_url.replace('http://local.test/',
+                                           'https://local.test:443/')
+        api_url = url_for('api.oembed', url=url)
 
-        assert200(api.get(api_url, base_url="https://local.test:443/"))
+        assert200(api.get(api_url, base_url='https://local.test:443/'))
 
     def test_oembed_does_not_support_xml(self, api):
-        """It does not support xml format."""
+        '''It does not support xml format.'''
         dataset = DatasetFactory()
-        url = url_for("api.oembed", url=dataset.external_url, format="xml")
-        response = api.get(
-            url,
-            headers={"Origin": "http://localhost"},
-        )
+        url = url_for('api.oembed', url=dataset.external_url, format='xml')
+        response = api.get(url)
         assert_status(response, 501)
         assert_cors(response)
-        assert response.json["message"] == "Only JSON format is supported"
+        assert response.json['message'] == 'Only JSON format is supported'
 
 
 def territory_dataset_factory():
@@ -199,8 +170,8 @@ def territory_dataset_factory():
         title = faker.sentence()
         organization_id = str(org.id)
         description = faker.paragraph()
-        temporal_coverage = {"start": 2007, "end": 2012}
-        url_template = "http://somehere.com/{code}"
+        temporal_coverage = {'start': 2007, 'end': 2012}
+        url_template = 'http://somehere.com/{code}'
 
     return TestDataset
 
@@ -209,8 +180,8 @@ class OEmbedSettings(Testing):
     ACTIVATE_TERRITORIES = True
     TEST_WITH_THEME = True
     TEST_WITH_PLUGINS = True
-    PLUGINS = ["front"]
-    THEME = "gouvfr"
+    PLUGINS = ['front']
+    THEME = 'gouvfr'
 
 
 class OEmbedsDatasetAPITest:
@@ -226,149 +197,150 @@ class OEmbedsDatasetAPITest:
         TERRITORY_DATASETS.update(self.territory_datasets_backup)
 
     def test_oembeds_dataset_api_get(self, api):
-        """It should fetch a dataset in the oembed format."""
+        '''It should fetch a dataset in the oembed format.'''
         dataset = DatasetFactory()
 
-        url = url_for("api.oembeds", references="dataset-{id}".format(id=dataset.id))
+        url = url_for('api.oembeds',
+                      references='dataset-{id}'.format(id=dataset.id))
         response = api.get(url)
         assert200(response)
         data = response.json[0]
-        assert "html" in data
-        assert "width" in data
-        assert "maxwidth" in data
-        assert "height" in data
-        assert "maxheight" in data
-        assert data["type"] == "rich"
-        assert data["version"] == "1.0"
-        assert dataset.title in data["html"]
-        assert dataset.external_url in data["html"]
-        assert "placeholders/default.png" in data["html"]
-        assert mdstrip(dataset.description, 110) in data["html"]
+        assert 'html' in data
+        assert 'width' in data
+        assert 'maxwidth' in data
+        assert 'height' in data
+        assert 'maxheight' in data
+        assert data['type'] == 'rich'
+        assert data['version'] == '1.0'
+        assert dataset.title in data['html']
+        assert dataset.external_url in data['html']
+        assert 'placeholders/default.png' in data['html']
+        assert mdstrip(dataset.description, 110) in data['html']
 
     def test_oembeds_dataset_api_get_with_organization(self, api):
-        """It should fetch a dataset in the oembed format with org."""
+        '''It should fetch a dataset in the oembed format with org.'''
         organization = OrganizationFactory()
         dataset = DatasetFactory(organization=organization)
 
-        url = url_for("api.oembeds", references="dataset-{id}".format(id=dataset.id))
+        url = url_for('api.oembeds',
+                      references='dataset-{id}'.format(id=dataset.id))
         response = api.get(url)
         assert200(response)
         data = response.json[0]
-        assert organization.name in data["html"]
-        assert organization.external_url in data["html"]
+        assert organization.name in data['html']
+        assert organization.external_url in data['html']
 
     def test_oembeds_dataset_api_get_without_references(self, api):
-        """It should fail at fetching an oembed without a dataset."""
-        response = api.get(url_for("api.oembeds"))
+        '''It should fail at fetching an oembed without a dataset.'''
+        response = api.get(url_for('api.oembeds'))
         assert400(response)
-        assert "references" in response.json["errors"]
+        assert 'references' in response.json['errors']
 
     def test_oembeds_dataset_api_get_without_good_id(self, api):
-        """It should fail at fetching an oembed without a good id."""
-        response = api.get(url_for("api.oembeds", references="123456789"))
+        '''It should fail at fetching an oembed without a good id.'''
+        response = api.get(url_for('api.oembeds', references='123456789'))
         assert400(response)
-        assert response.json["message"] == "Invalid ID."
+        assert response.json['message'] == 'Invalid ID.'
 
     def test_oembeds_dataset_api_get_without_good_item(self, api):
-        """It should fail at fetching an oembed with a wrong item."""
+        '''It should fail at fetching an oembed with a wrong item.'''
         user = UserFactory()
 
-        url = url_for("api.oembeds", references="user-{id}".format(id=user.id))
+        url = url_for('api.oembeds', references='user-{id}'.format(id=user.id))
         response = api.get(url)
         assert400(response)
-        assert response.json["message"] == "Invalid object type."
+        assert response.json['message'] == 'Invalid object type.'
 
     def test_oembeds_dataset_api_get_without_valid_id(self, api):
-        """It should fail at fetching an oembed without a valid id."""
-        url = url_for("api.oembeds", references="dataset-123456789")
+        '''It should fail at fetching an oembed without a valid id.'''
+        url = url_for('api.oembeds', references='dataset-123456789')
         response = api.get(url)
         assert400(response)
-        assert response.json["message"] == "Unknown dataset ID."
+        assert response.json['message'] == 'Unknown dataset ID.'
 
     def test_oembeds_api_for_territory(self, api):
-        """It should fetch a territory in the oembed format."""
+        '''It should fetch a territory in the oembed format.'''
         country = faker.country_code().lower()
-        level = "commune"
-        zone = GeoZoneFactory(level="{0}:{1}".format(country, level))
+        level = 'commune'
+        zone = GeoZoneFactory(level='{0}:{1}'.format(country, level))
         TestDataset = territory_dataset_factory()
         TERRITORY_DATASETS[level][TestDataset.id] = TestDataset
-        reference = "territory-{0}:{1}".format(zone.id, TestDataset.id)
-        url = url_for("api.oembeds", references=reference)
+        reference = 'territory-{0}:{1}'.format(zone.id, TestDataset.id)
+        url = url_for('api.oembeds', references=reference)
         response = api.get(url)
         assert200(response)
         data = response.json[0]
-        assert "html" in data
-        assert "width" in data
-        assert "maxwidth" in data
-        assert "height" in data
-        assert "maxheight" in data
-        assert data["type"] == "rich"
-        assert data["version"] == "1.0"
-        assert zone.name in data["html"]
-        assert "placeholders/default.png" in data["html"]
+        assert 'html' in data
+        assert 'width' in data
+        assert 'maxwidth' in data
+        assert 'height' in data
+        assert 'maxheight' in data
+        assert data['type'] == 'rich'
+        assert data['version'] == '1.0'
+        assert zone.name in data['html']
+        assert 'placeholders/default.png' in data['html']
 
     def test_oembeds_api_for_territory_resolve_geoid(self, api):
-        """It should fetch a territory from a geoid in the oembed format."""
+        '''It should fetch a territory from a geoid in the oembed format.'''
         country = faker.country_code().lower()
-        level = "commune"
-        zone = GeoZoneFactory(level="{0}:{1}".format(country, level))
+        level = 'commune'
+        zone = GeoZoneFactory(level='{0}:{1}'.format(country, level))
         TestDataset = territory_dataset_factory()
         TERRITORY_DATASETS[level][TestDataset.id] = TestDataset
-        geoid = "{0.level}:{0.code}@latest".format(zone)
-        reference = "territory-{0}:{1}".format(geoid, TestDataset.id)
+        geoid = '{0.level}:{0.code}@latest'.format(zone)
+        reference = 'territory-{0}:{1}'.format(geoid, TestDataset.id)
 
-        url = url_for("api.oembeds", references=reference)
+        url = url_for('api.oembeds', references=reference)
         response = api.get(url)
         assert200(response)
         data = response.json[0]
-        assert "html" in data
-        assert "width" in data
-        assert "maxwidth" in data
-        assert "height" in data
-        assert "maxheight" in data
-        assert data["type"] == "rich"
-        assert data["version"] == "1.0"
-        assert zone.name in data["html"]
-        assert "placeholders/default.png" in data["html"]
+        assert 'html' in data
+        assert 'width' in data
+        assert 'maxwidth' in data
+        assert 'height' in data
+        assert 'maxheight' in data
+        assert data['type'] == 'rich'
+        assert data['version'] == '1.0'
+        assert zone.name in data['html']
+        assert 'placeholders/default.png' in data['html']
 
     def test_oembeds_api_for_territory_bad_id(self, api):
-        """Should raise 400 on bad territory ID"""
-        url = url_for("api.oembeds", references="territory-xyz")
+        '''Should raise 400 on bad territory ID'''
+        url = url_for('api.oembeds', references='territory-xyz')
         response = api.get(url)
         assert400(response)
-        assert response.json["message"] == "Invalid territory ID."
+        assert response.json['message'] == 'Invalid territory ID.'
 
     def test_oembeds_api_for_territory_zone_not_found(self, api):
-        """Should raise 400 on unknown zone ID"""
-        url = url_for(
-            "api.oembeds", references="territory-fr:commune:13004@1970-01-01:xyz"
-        )
+        '''Should raise 400 on unknown zone ID'''
+        url = url_for('api.oembeds',
+                      references='territory-fr:commune:13004@1970-01-01:xyz')
         response = api.get(url)
         assert400(response)
-        assert response.json["message"] == "Unknown territory identifier."
+        assert response.json['message'] == 'Unknown territory identifier.'
 
     def test_oembeds_api_for_territory_level_not_registered(self, api):
-        """Should raise 400 on unregistered territory level"""
+        '''Should raise 400 on unregistered territory level'''
         country = faker.country_code().lower()
-        level = "commune"
-        zone = GeoZoneFactory(level="{0}:{1}".format(country, level))
+        level = 'commune'
+        zone = GeoZoneFactory(level='{0}:{1}'.format(country, level))
         TestDataset = territory_dataset_factory()
         del TERRITORY_DATASETS[level]
-        reference = "territory-{0}:{1}".format(zone.id, TestDataset.id)
-        url = url_for("api.oembeds", references=reference)
+        reference = 'territory-{0}:{1}'.format(zone.id, TestDataset.id)
+        url = url_for('api.oembeds', references=reference)
         response = api.get(url)
         assert400(response)
-        assert response.json["message"] == "Unknown kind of territory."
+        assert response.json['message'] == 'Unknown kind of territory.'
 
     def test_oembeds_api_for_territory_dataset_not_registered(self, api):
-        """Should raise 400 on unregistered territory dataset"""
+        '''Should raise 400 on unregistered territory dataset'''
         country = faker.country_code().lower()
-        level = "commune"
-        zone = GeoZoneFactory(level="{0}:{1}".format(country, level))
+        level = 'commune'
+        zone = GeoZoneFactory(level='{0}:{1}'.format(country, level))
         TestDataset = territory_dataset_factory()
         TERRITORY_DATASETS[level] = {}
-        reference = "territory-{0}:{1}".format(zone.id, TestDataset.id)
-        url = url_for("api.oembeds", references=reference)
+        reference = 'territory-{0}:{1}'.format(zone.id, TestDataset.id)
+        url = url_for('api.oembeds', references=reference)
         response = api.get(url)
         assert400(response)
-        assert response.json["message"] == "Unknown territory dataset id."
+        assert response.json['message'] == 'Unknown territory dataset id.'

--- a/udata_front/tests/views/test_oembed.py
+++ b/udata_front/tests/views/test_oembed.py
@@ -31,7 +31,7 @@ class OEmbedAPITest:
 
         url = url_for('api.oembed', url=dataset.external_url)
 
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert200(response)
         assert_cors(response)
         assert 'html' in response.json
@@ -51,7 +51,7 @@ class OEmbedAPITest:
 
         url = url_for('api.oembed', url=dataset.external_url)
 
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert200(response)
         assert_cors(response)
 
@@ -65,7 +65,7 @@ class OEmbedAPITest:
                                dataset=dataset, _external=True)
 
         url = url_for('api.oembed', url=redirect_url)
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert200(response)
         assert_cors(response)
         assert 'html' in response.json
@@ -83,7 +83,7 @@ class OEmbedAPITest:
         dataset_url = url_for('datasets.show', dataset='unknown',
                               _external=True)
         url = url_for('api.oembed', url=dataset_url)
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert404(response)
         assert_cors(response)
 
@@ -92,7 +92,7 @@ class OEmbedAPITest:
         reuse = ReuseFactory()
 
         url = url_for('api.oembed', url=reuse.external_url)
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert200(response)
         assert_cors(response)
         assert 'html' in response.json
@@ -110,7 +110,7 @@ class OEmbedAPITest:
         org = OrganizationFactory()
 
         url = url_for('api.oembed', url=org.external_url)
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert200(response)
         assert_cors(response)
         assert 'html' in response.json
@@ -138,7 +138,7 @@ class OEmbedAPITest:
     def test_oembed_with_an_unknown_url(self, api):
         '''It should fail at fetching an oembed with an invalid URL.'''
         url = url_for('api.oembed', url='http://local.test/somewhere')
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert404(response)
         assert_cors(response)
 
@@ -155,7 +155,7 @@ class OEmbedAPITest:
         '''It does not support xml format.'''
         dataset = DatasetFactory()
         url = url_for('api.oembed', url=dataset.external_url, format='xml')
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert_status(response, 501)
         assert_cors(response)
         assert response.json['message'] == 'Only JSON format is supported'
@@ -202,7 +202,7 @@ class OEmbedsDatasetAPITest:
 
         url = url_for('api.oembeds',
                       references='dataset-{id}'.format(id=dataset.id))
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert200(response)
         data = response.json[0]
         assert 'html' in data
@@ -224,7 +224,7 @@ class OEmbedsDatasetAPITest:
 
         url = url_for('api.oembeds',
                       references='dataset-{id}'.format(id=dataset.id))
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert200(response)
         data = response.json[0]
         assert organization.name in data['html']
@@ -247,14 +247,14 @@ class OEmbedsDatasetAPITest:
         user = UserFactory()
 
         url = url_for('api.oembeds', references='user-{id}'.format(id=user.id))
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert400(response)
         assert response.json['message'] == 'Invalid object type.'
 
     def test_oembeds_dataset_api_get_without_valid_id(self, api):
         '''It should fail at fetching an oembed without a valid id.'''
         url = url_for('api.oembeds', references='dataset-123456789')
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert400(response)
         assert response.json['message'] == 'Unknown dataset ID.'
 
@@ -267,7 +267,7 @@ class OEmbedsDatasetAPITest:
         TERRITORY_DATASETS[level][TestDataset.id] = TestDataset
         reference = 'territory-{0}:{1}'.format(zone.id, TestDataset.id)
         url = url_for('api.oembeds', references=reference)
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert200(response)
         data = response.json[0]
         assert 'html' in data
@@ -291,7 +291,7 @@ class OEmbedsDatasetAPITest:
         reference = 'territory-{0}:{1}'.format(geoid, TestDataset.id)
 
         url = url_for('api.oembeds', references=reference)
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert200(response)
         data = response.json[0]
         assert 'html' in data
@@ -307,7 +307,7 @@ class OEmbedsDatasetAPITest:
     def test_oembeds_api_for_territory_bad_id(self, api):
         '''Should raise 400 on bad territory ID'''
         url = url_for('api.oembeds', references='territory-xyz')
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert400(response)
         assert response.json['message'] == 'Invalid territory ID.'
 
@@ -315,7 +315,7 @@ class OEmbedsDatasetAPITest:
         '''Should raise 400 on unknown zone ID'''
         url = url_for('api.oembeds',
                       references='territory-fr:commune:13004@1970-01-01:xyz')
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert400(response)
         assert response.json['message'] == 'Unknown territory identifier.'
 
@@ -328,7 +328,7 @@ class OEmbedsDatasetAPITest:
         del TERRITORY_DATASETS[level]
         reference = 'territory-{0}:{1}'.format(zone.id, TestDataset.id)
         url = url_for('api.oembeds', references=reference)
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert400(response)
         assert response.json['message'] == 'Unknown kind of territory.'
 
@@ -341,6 +341,6 @@ class OEmbedsDatasetAPITest:
         TERRITORY_DATASETS[level] = {}
         reference = 'territory-{0}:{1}'.format(zone.id, TestDataset.id)
         url = url_for('api.oembeds', references=reference)
-        response = api.get(url, headers={ 'Origin': 'http://localhost' })
+        response = api.get(url, headers={'Origin': 'http://localhost'})
         assert400(response)
         assert response.json['message'] == 'Unknown territory dataset id.'


### PR DESCRIPTION
Following https://github.com/opendatateam/udata/pull/3074 we need to send an `Origin` header to get the `Access-Control-Allow-Origin` otherwise the request is not a cross origin request.