### PR TITLE
Add captchetat to reset route

### DIFF
--- a/udata_front/frontend/__init__.py
+++ b/udata_front/frontend/__init__.py
@@ -85,10 +85,11 @@ def init_app(app):
     if app.config.get('CAPTCHETAT_BASE_URL'):
         # Security override init
         from udata.auth import security
-        from udata_front.forms import ExtendedRegisterForm
+        from udata_front.forms import ExtendedRegisterForm, ExtendedForgotPasswordForm
         with app.app_context():
             security.forms['register_form'].cls = ExtendedRegisterForm
             security.forms['confirm_register_form'].cls = ExtendedRegisterForm
+            security.forms['forgot_password_form'].cls = ExtendedForgotPasswordForm
 
     if app.config.get('MONCOMPETPRO_OPENID_CONF_URL'):
         # MonComptPro SSO

--- a/udata_front/tests/test_forms.py
+++ b/udata_front/tests/test_forms.py
@@ -32,8 +32,6 @@ class ExtendedRegisterFormTest(GouvfrFrontTestCase):
         assert result is False
         assert 'first_name' in form.errors
         assert 'last_name' in form.errors
-        assert 'captcha_code' in form.errors
-        assert 'captcha_id' in form.errors
 
     def test_register_form_accepts_no_url(self):
         form = ExtendedRegisterForm.from_json({

--- a/udata_front/theme/gouvfr/templates/security/forgot_password.html
+++ b/udata_front/theme/gouvfr/templates/security/forgot_password.html
@@ -1,4 +1,5 @@
 {% extends theme('base.html') %}
+{% from theme('macros/banner_warning.html') import banner_warning %}
 {% import theme('macros/forms.html') as forms with context %}
 
 {% block content %}
@@ -14,7 +15,35 @@
                     <p class="fr-my-1w fr-text--xs text-align-left">
                         {{ _("Fields preceded by a star (<span class='required-field-star'>*</span>) are required.") }}
                     </p>
-                    {{ forms.render_fields(forgot_password_form, submit=_('Reset Password')) }}
+                    {% if config.CAPTCHETAT_BASE_URL %}
+                        <noscript>
+                        {{ banner_warning(
+                            "fr-icon-alert-line",
+                            _("Javascript is required to use this page correctly.")
+                        )}}
+                        </noscript>
+                        {{ forms.render_fields(forgot_password_form, exclude=[forgot_password_form.submit, forgot_password_form.captcha_code, forgot_password_form.captcha_id]) }}
+                        <div class="vuejs">
+                            <captcha captcha-style-name="captchaFR"></captcha>
+                            <label class="fr-label fr-mt-1w text-align-left">
+                                {{ _("Retype the characters from the picture") }} <span class='required-field-star'>*</span>
+                            </label>
+                            <input id="captchaFormulaireExtInput" name="captcha_code" type="text" required="required"/>
+                            {% for error in forgot_password_form.captcha_code.errors %}
+                            <p class="fr-error-text fr-mt-1v">{{ error }}</p>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        {{ forms.render_fields(forgot_password_form, exclude=[forgot_password_form.submit]) }}
+                    {% endif %}
+                    <div class="fr-mt-1w fr-grid-row fr-grid-row--center">
+                        <button
+                            type="submit"
+                            class="fr-btn"
+                        >
+                            {{ _('Reset Password') }}
+                        </button>
+                    </div>
                 </form>
             </div>
         </div>


### PR DESCRIPTION
Code from https://github.com/datagouv/udata-front/pull/273.

Moved the captcha check before the `super().validate()` to prevent checking email existance without captcha.

Fix https://github.com/datagouv/data.gouv.fr/issues/1403