### PR TITLE
Fix/components i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix tests for oembed CORS [#453](https://github.com/datagouv/udata-front/pull/453)
 - Add reports [#436](https://github.com/datagouv/udata-front/pull/436)
 - Switch to @datagouv/components [#439](https://github.com/datagouv/udata-front/pull/439)
+- Update translations [#458](https://github.com/datagouv/udata-front/pull/458)
 
 ## 5.0.1 (2024-06-12)
 

--- a/udata_front/theme/gouvfr/assets/js/locales/de.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/de.json
@@ -461,5 +461,22 @@
   "An error occured when deleting the organization.": "An error occured when deleting the organization.",
   "Organization updated !": "Organization updated !",
   "An error occured when updating the organization.": "An error occured when updating the organization.",
-  "Thanks for reporting this content": "Thanks for reporting this content"
+  "Thanks for reporting this content": "Thanks for reporting this content",
+  "Add member": "",
+  "Add member to the organization": "",
+  "Search a user": "",
+  "Search a user...": "",
+  "Select a user": "",
+  "Add to the organization": "",
+  "An error occurred while update member role.": "",
+  "Check the identity with which you want to publish": "",
+  "Select an organization": "",
+  "You belong to no organization": "",
+  "You publish in your own name": "",
+  "We advise you to publish under an organization if it\\'s a professional activity": "",
+  "Join an organization": "",
+  "Make a report": "",
+  "An unexpected error occured while reporting this content.": "",
+  "Producer": "",
+  "You need to select a Producer": ""
 }

--- a/udata_front/theme/gouvfr/assets/js/locales/en.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/en.json
@@ -461,5 +461,22 @@
   "An error occured when deleting the organization.": "An error occured when deleting the organization.",
   "Organization updated !": "Organization updated !",
   "An error occured when updating the organization.": "An error occured when updating the organization.",
-  "Thanks for reporting this content": "Thanks for reporting this content"
+  "Thanks for reporting this content": "Thanks for reporting this content",
+  "Add member": "Add member",
+  "Add member to the organization": "Add member to the organization",
+  "Search a user": "Search a user",
+  "Search a user...": "Search a user...",
+  "Select a user": "Select a user",
+  "Add to the organization": "Add to the organization",
+  "An error occurred while update member role.": "An error occurred while update member role.",
+  "Check the identity with which you want to publish": "Check the identity with which you want to publish",
+  "Select an organization": "Select an organization",
+  "You belong to no organization": "You belong to no organization",
+  "You publish in your own name": "You publish in your own name",
+  "We advise you to publish under an organization if it\\'s a professional activity": "We advise you to publish under an organization if it\\'s a professional activity",
+  "Join an organization": "Join an organization",
+  "Make a report": "Make a report",
+  "An unexpected error occured while reporting this content.": "An unexpected error occured while reporting this content.",
+  "Producer": "Producer",
+  "You need to select a Producer": "You need to select a Producer"
 }

--- a/udata_front/theme/gouvfr/assets/js/locales/es.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/es.json
@@ -461,5 +461,22 @@
   "An error occured when deleting the organization.": "An error occured when deleting the organization.",
   "Organization updated !": "Organization updated !",
   "An error occured when updating the organization.": "An error occured when updating the organization.",
-  "Thanks for reporting this content": "Thanks for reporting this content"
+  "Thanks for reporting this content": "Thanks for reporting this content",
+  "Add member": "",
+  "Add member to the organization": "",
+  "Search a user": "",
+  "Search a user...": "",
+  "Select a user": "",
+  "Add to the organization": "",
+  "An error occurred while update member role.": "",
+  "Check the identity with which you want to publish": "",
+  "Select an organization": "",
+  "You belong to no organization": "",
+  "You publish in your own name": "",
+  "We advise you to publish under an organization if it\\'s a professional activity": "",
+  "Join an organization": "",
+  "Make a report": "",
+  "An unexpected error occured while reporting this content.": "",
+  "Producer": "",
+  "You need to select a Producer": ""
 }

--- a/udata_front/theme/gouvfr/assets/js/locales/fr.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/fr.json
@@ -461,5 +461,22 @@
   "An error occured when deleting the organization.": "Une erreur s'est produite lors de la suppression de l'organisation.",
   "Organization updated !": "Organisation mise à jour !",
   "An error occured when updating the organization.": "Une erreur s'est produite lors de la mise à jour de l'organisation.",
-  "Thanks for reporting this content": "Merci d'avoir signalé ce contenu"
+  "Thanks for reporting this content": "Merci d'avoir signalé ce contenu",
+  "Add member": "",
+  "Add member to the organization": "",
+  "Search a user": "",
+  "Search a user...": "",
+  "Select a user": "",
+  "Add to the organization": "",
+  "An error occurred while update member role.": "",
+  "Check the identity with which you want to publish": "",
+  "Select an organization": "",
+  "You belong to no organization": "",
+  "You publish in your own name": "",
+  "We advise you to publish under an organization if it\\'s a professional activity": "",
+  "Join an organization": "",
+  "Make a report": "",
+  "An unexpected error occured while reporting this content.": "",
+  "Producer": "",
+  "You need to select a Producer": ""
 }

--- a/udata_front/theme/gouvfr/assets/js/locales/it.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/it.json
@@ -461,5 +461,22 @@
   "An error occured when deleting the organization.": "An error occured when deleting the organization.",
   "Organization updated !": "Organization updated !",
   "An error occured when updating the organization.": "An error occured when updating the organization.",
-  "Thanks for reporting this content": "Thanks for reporting this content"
+  "Thanks for reporting this content": "Thanks for reporting this content",
+  "Add member": "",
+  "Add member to the organization": "",
+  "Search a user": "",
+  "Search a user...": "",
+  "Select a user": "",
+  "Add to the organization": "",
+  "An error occurred while update member role.": "",
+  "Check the identity with which you want to publish": "",
+  "Select an organization": "",
+  "You belong to no organization": "",
+  "You publish in your own name": "",
+  "We advise you to publish under an organization if it\\'s a professional activity": "",
+  "Join an organization": "",
+  "Make a report": "",
+  "An unexpected error occured while reporting this content.": "",
+  "Producer": "",
+  "You need to select a Producer": ""
 }

--- a/udata_front/theme/gouvfr/assets/js/locales/pt.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/pt.json
@@ -461,5 +461,22 @@
   "An error occured when deleting the organization.": "An error occured when deleting the organization.",
   "Organization updated !": "Organization updated !",
   "An error occured when updating the organization.": "An error occured when updating the organization.",
-  "Thanks for reporting this content": "Thanks for reporting this content"
+  "Thanks for reporting this content": "Thanks for reporting this content",
+  "Add member": "",
+  "Add member to the organization": "",
+  "Search a user": "",
+  "Search a user...": "",
+  "Select a user": "",
+  "Add to the organization": "",
+  "An error occurred while update member role.": "",
+  "Check the identity with which you want to publish": "",
+  "Select an organization": "",
+  "You belong to no organization": "",
+  "You publish in your own name": "",
+  "We advise you to publish under an organization if it\\'s a professional activity": "",
+  "Join an organization": "",
+  "Make a report": "",
+  "An unexpected error occured while reporting this content.": "",
+  "Producer": "",
+  "You need to select a Producer": ""
 }

--- a/udata_front/theme/gouvfr/assets/js/locales/sr.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/sr.json
@@ -461,5 +461,22 @@
   "An error occured when deleting the organization.": "An error occured when deleting the organization.",
   "Organization updated !": "Organization updated !",
   "An error occured when updating the organization.": "An error occured when updating the organization.",
-  "Thanks for reporting this content": "Thanks for reporting this content"
+  "Thanks for reporting this content": "Thanks for reporting this content",
+  "Add member": "",
+  "Add member to the organization": "",
+  "Search a user": "",
+  "Search a user...": "",
+  "Select a user": "",
+  "Add to the organization": "",
+  "An error occurred while update member role.": "",
+  "Check the identity with which you want to publish": "",
+  "Select an organization": "",
+  "You belong to no organization": "",
+  "You publish in your own name": "",
+  "We advise you to publish under an organization if it\\'s a professional activity": "",
+  "Join an organization": "",
+  "Make a report": "",
+  "An unexpected error occured while reporting this content.": "",
+  "Producer": "",
+  "You need to select a Producer": ""
 }

--- a/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
+++ b/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Allow quality score warning to be hidden [#414](https://github.com/datagouv/udata-front/pull/414)
 - Add preview to resource component [#433](https://github.com/datagouv/udata-front/pull/433)
 - Add useAccordion composable and add missing exports [#451](https://github.com/datagouv/udata-front/pull/451)
+- Add translations [#458](https://github.com/datagouv/udata-front/pull/458)

--- a/udata_front/theme/gouvfr/datagouv-components/package.json
+++ b/udata_front/theme/gouvfr/datagouv-components/package.json
@@ -25,7 +25,7 @@
     "publish-dev": "npm run publish-stable -- --tag=dev",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "chromatic": "npx chromatic --only-changed"
+    "chromatic": "npx chromatic --only-changed --externals './src/locales/**/*.json'"
   },
   "dependencies": {
     "vue": "^3.3.8"

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerType.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerType.vue
@@ -19,7 +19,7 @@ const { t } = useI18n();
  const name = computed(() => {
   switch (props.type) {
     case PUBLIC_SERVICE:
-      return t("Service public");
+      return t("Public service");
     case LOCAL_AUTHORITY:
       return t("Local authority");
     case ASSOCIATION:

--- a/udata_front/theme/gouvfr/datagouv-components/src/locales/de.json
+++ b/udata_front/theme/gouvfr/datagouv-components/src/locales/de.json
@@ -95,5 +95,10 @@
   "Sort descending": "Sort descending",
   "{count} columns": "{count} columns",
   "{count} rows": "{count} rows",
-  "Resource Extras": "Resource Extras"
+  "Resource Extras": "Resource Extras",
+  "Public service": "",
+  "Local authority": "",
+  "Association": "",
+  "Company": "",
+  "User": ""
 }

--- a/udata_front/theme/gouvfr/datagouv-components/src/locales/en.json
+++ b/udata_front/theme/gouvfr/datagouv-components/src/locales/en.json
@@ -95,5 +95,10 @@
   "Sort descending": "Sort descending",
   "{count} columns": "{count} columns",
   "{count} rows": "{count} rows",
-  "Resource Extras": "Resource Extras"
+  "Resource Extras": "Resource Extras",
+  "Public service": "Public service",
+  "Local authority": "",
+  "Association": "",
+  "Company": "",
+  "User": ""
 }

--- a/udata_front/theme/gouvfr/datagouv-components/src/locales/en.json
+++ b/udata_front/theme/gouvfr/datagouv-components/src/locales/en.json
@@ -97,8 +97,8 @@
   "{count} rows": "{count} rows",
   "Resource Extras": "Resource Extras",
   "Public service": "Public service",
-  "Local authority": "",
-  "Association": "",
-  "Company": "",
-  "User": ""
+  "Local authority": "Local authority",
+  "Association": "Association",
+  "Company": "Company",
+  "User": "User"
 }

--- a/udata_front/theme/gouvfr/datagouv-components/src/locales/es.json
+++ b/udata_front/theme/gouvfr/datagouv-components/src/locales/es.json
@@ -95,5 +95,10 @@
   "Sort descending": "Sort descending",
   "{count} columns": "{count} columns",
   "{count} rows": "{count} rows",
-  "Resource Extras": "Resource Extras"
+  "Resource Extras": "Resource Extras",
+  "Public service": "",
+  "Local authority": "",
+  "Association": "",
+  "Company": "",
+  "User": ""
 }

--- a/udata_front/theme/gouvfr/datagouv-components/src/locales/fr.json
+++ b/udata_front/theme/gouvfr/datagouv-components/src/locales/fr.json
@@ -95,5 +95,10 @@
   "Sort descending": "Trier par ordre décroissant",
   "{count} columns": "{count} colonnes",
   "{count} rows": "Lignes {count}",
-  "Resource Extras": "Extras de la ressource"
+  "Resource Extras": "Extras de la ressource",
+  "Public service": "",
+  "Local authority": "",
+  "Association": "",
+  "Company": "",
+  "User": ""
 }

--- a/udata_front/theme/gouvfr/datagouv-components/src/locales/it.json
+++ b/udata_front/theme/gouvfr/datagouv-components/src/locales/it.json
@@ -95,5 +95,10 @@
   "Sort descending": "Sort descending",
   "{count} columns": "{count} columns",
   "{count} rows": "{count} rows",
-  "Resource Extras": "Resource Extras"
+  "Resource Extras": "Resource Extras",
+  "Public service": "",
+  "Local authority": "",
+  "Association": "",
+  "Company": "",
+  "User": ""
 }

--- a/udata_front/theme/gouvfr/datagouv-components/src/locales/pt.json
+++ b/udata_front/theme/gouvfr/datagouv-components/src/locales/pt.json
@@ -95,5 +95,10 @@
   "Sort descending": "Sort descending",
   "{count} columns": "{count} columns",
   "{count} rows": "{count} rows",
-  "Resource Extras": "Resource Extras"
+  "Resource Extras": "Resource Extras",
+  "Public service": "",
+  "Local authority": "",
+  "Association": "",
+  "Company": "",
+  "User": ""
 }

--- a/udata_front/theme/gouvfr/datagouv-components/src/locales/sr.json
+++ b/udata_front/theme/gouvfr/datagouv-components/src/locales/sr.json
@@ -95,5 +95,10 @@
   "Sort descending": "Sort descending",
   "{count} columns": "{count} columns",
   "{count} rows": "{count} rows",
-  "Resource Extras": "Resource Extras"
+  "Resource Extras": "Resource Extras",
+  "Public service": "",
+  "Local authority": "",
+  "Association": "",
+  "Company": "",
+  "User": ""
 }

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: udata-front 5.0.2.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2024-07-08 11:19+0200\n"
-"PO-Revision-Date: 2024-07-08 11:19+0200\n"
+"POT-Creation-Date: 2024-07-29 11:16+0200\n"
+"PO-Revision-Date: 2024-07-29 11:16+0200\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -39,15 +39,15 @@ msgstr ""
 msgid "Last name is required"
 msgstr ""
 
-#: udata_front/forms.py:20
+#: udata_front/forms.py:19 udata_front/forms.py:35
 msgid "captcha_input"
 msgstr ""
 
-#: udata_front/forms.py:23
+#: udata_front/forms.py:21 udata_front/forms.py:37
 msgid "captcha_id"
 msgstr ""
 
-#: udata_front/forms.py:39
+#: udata_front/forms.py:28 udata_front/forms.py:41
 msgid "Invalid Captcha"
 msgstr ""
 
@@ -96,16 +96,16 @@ msgid "Data"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:47
-#: udata_front/theme/gouvfr/templates/dataset/display.html:216
-#: udata_front/theme/gouvfr/templates/dataset/display.html:281
+#: udata_front/theme/gouvfr/templates/dataset/display.html:218
+#: udata_front/theme/gouvfr/templates/dataset/display.html:283
 #: udata_front/theme/gouvfr/templates/home.html:84
-#: udata_front/theme/gouvfr/templates/organization/display.html:26
-#: udata_front/theme/gouvfr/templates/organization/display.html:128
-#: udata_front/theme/gouvfr/templates/organization/display.html:172
+#: udata_front/theme/gouvfr/templates/organization/display.html:27
+#: udata_front/theme/gouvfr/templates/organization/display.html:130
+#: udata_front/theme/gouvfr/templates/organization/display.html:174
 #: udata_front/theme/gouvfr/templates/organization/list.html:26
 #: udata_front/theme/gouvfr/templates/page.html:39
 #: udata_front/theme/gouvfr/templates/post/display.html:81
-#: udata_front/theme/gouvfr/templates/reuse/display.html:36
+#: udata_front/theme/gouvfr/templates/reuse/display.html:37
 #: udata_front/theme/gouvfr/templates/reuse/list.html:6
 #: udata_front/theme/gouvfr/templates/reuse/list.html:17
 #: udata_front/theme/gouvfr/templates/reuse/list.html:49
@@ -118,7 +118,7 @@ msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:48
 #: udata_front/theme/gouvfr/templates/home.html:86
-#: udata_front/theme/gouvfr/templates/organization/display.html:35
+#: udata_front/theme/gouvfr/templates/organization/display.html:36
 #: udata_front/theme/gouvfr/templates/organization/list.html:6
 #: udata_front/theme/gouvfr/templates/organization/list.html:17
 #: udata_front/theme/gouvfr/templates/organization/list.html:31
@@ -241,8 +241,8 @@ msgstr[1] ""
 msgid "Download from "
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:82
-#: udata_front/theme/gouvfr/templates/dataset/display.html:117
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:84
+#: udata_front/theme/gouvfr/templates/dataset/display.html:119
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:177
 msgid "Producer"
 msgstr ""
@@ -261,12 +261,12 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:634
+#: udata_front/theme/gouvfr/templates/dataset/display.html:636
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:206
 msgid "Embed"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:568
+#: udata_front/theme/gouvfr/templates/dataset/display.html:570
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:209
 msgid "Temporal coverage"
 msgstr ""
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Territory"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:563
+#: udata_front/theme/gouvfr/templates/dataset/display.html:565
 #: udata_front/theme/gouvfr/templates/embed-dataset.html:232
 msgid "Frequency"
 msgstr ""
@@ -432,7 +432,7 @@ msgstr ""
 msgid "All news"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:39
+#: udata_front/theme/gouvfr/templates/dataset/display.html:40
 #: udata_front/theme/gouvfr/templates/dataset/followers.html:6
 #: udata_front/theme/gouvfr/templates/dataset/list.html:8
 #: udata_front/theme/gouvfr/templates/dataset/list.html:14
@@ -440,8 +440,8 @@ msgstr ""
 #: udata_front/theme/gouvfr/templates/dataset/publishing-form.html:16
 #: udata_front/theme/gouvfr/templates/home.html:82
 #: udata_front/theme/gouvfr/templates/home.html:125
-#: udata_front/theme/gouvfr/templates/organization/display.html:110
-#: udata_front/theme/gouvfr/templates/organization/display.html:162
+#: udata_front/theme/gouvfr/templates/organization/display.html:112
+#: udata_front/theme/gouvfr/templates/organization/display.html:164
 #: udata_front/theme/gouvfr/templates/page.html:32
 #: udata_front/theme/gouvfr/templates/post/display.html:72
 #: udata_front/theme/gouvfr/templates/topic/browse.html:9
@@ -451,8 +451,8 @@ msgstr ""
 msgid "Datasets"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:198
-#: udata_front/theme/gouvfr/templates/dataset/display.html:271
+#: udata_front/theme/gouvfr/templates/dataset/display.html:200
+#: udata_front/theme/gouvfr/templates/dataset/display.html:273
 #: udata_front/theme/gouvfr/templates/home.html:83
 msgid "Files"
 msgstr ""
@@ -470,11 +470,11 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:198
-#: udata_front/theme/gouvfr/templates/dataset/display.html:231
-#: udata_front/theme/gouvfr/templates/dataset/display.html:291
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:200
+#: udata_front/theme/gouvfr/templates/dataset/display.html:233
+#: udata_front/theme/gouvfr/templates/dataset/display.html:293
 #: udata_front/theme/gouvfr/templates/home.html:87
-#: udata_front/theme/gouvfr/templates/reuse/display.html:184
+#: udata_front/theme/gouvfr/templates/reuse/display.html:186
 msgid "Discussions"
 msgstr ""
 
@@ -581,7 +581,7 @@ msgstr ""
 msgid "RSS - new tab"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:633
+#: udata_front/theme/gouvfr/templates/dataset/display.html:635
 #: udata_front/theme/gouvfr/templates/page.html:52
 #: udata_front/theme/gouvfr/templates/post/display.html:95
 msgid "Actions"
@@ -617,9 +617,9 @@ msgid "Maintainer"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/api/admin.html:31
-#: udata_front/theme/gouvfr/templates/dataset/display.html:59
+#: udata_front/theme/gouvfr/templates/dataset/display.html:61
 #: udata_front/theme/gouvfr/templates/post/display.html:102
-#: udata_front/theme/gouvfr/templates/reuse/display.html:62
+#: udata_front/theme/gouvfr/templates/reuse/display.html:64
 #: udata_front/theme/gouvfr/templates/user/base.html:52
 msgid "Edit"
 msgstr ""
@@ -710,60 +710,60 @@ msgstr ""
 msgid "%(site)s administration panel"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:9
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:10
 msgid "API"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:25
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:26
 msgid "APIs"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:51
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:53
 msgid "This API is private and will not be visible by other users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:51
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:53
 #: udata_front/theme/gouvfr/templates/dataset/card-lg.html:13
 #: udata_front/theme/gouvfr/templates/dataset/card-sm.html:9
 #: udata_front/theme/gouvfr/templates/dataset/card-xs.html:10
-#: udata_front/theme/gouvfr/templates/dataset/display.html:76
+#: udata_front/theme/gouvfr/templates/dataset/display.html:78
 #: udata_front/theme/gouvfr/templates/reuse/card.html:11
-#: udata_front/theme/gouvfr/templates/reuse/display.html:79
+#: udata_front/theme/gouvfr/templates/reuse/display.html:81
 msgid "Private"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:58
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:60
 msgid "This API has been deleted. This will be permanent in the next 24 hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:58
-#: udata_front/theme/gouvfr/templates/dataset/display.html:83
-#: udata_front/theme/gouvfr/templates/organization/display.html:67
-#: udata_front/theme/gouvfr/templates/reuse/display.html:86
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:60
+#: udata_front/theme/gouvfr/templates/dataset/display.html:85
+#: udata_front/theme/gouvfr/templates/organization/display.html:69
+#: udata_front/theme/gouvfr/templates/reuse/display.html:88
 msgid "Deleted"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:65
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:67
 #: udata_front/theme/gouvfr/templates/dataset/card-lg.html:19
 #: udata_front/theme/gouvfr/templates/dataset/card-sm.html:15
 #: udata_front/theme/gouvfr/templates/dataset/card-xs.html:16
-#: udata_front/theme/gouvfr/templates/dataset/display.html:93
+#: udata_front/theme/gouvfr/templates/dataset/display.html:95
 msgid "Archived"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:77
-#: udata_front/theme/gouvfr/templates/dataset/display.html:105
-#: udata_front/theme/gouvfr/templates/organization/display.html:195
-#: udata_front/theme/gouvfr/templates/reuse/display.html:109
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:79
+#: udata_front/theme/gouvfr/templates/dataset/display.html:107
+#: udata_front/theme/gouvfr/templates/organization/display.html:197
+#: udata_front/theme/gouvfr/templates/reuse/display.html:111
 msgid "Description"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:87
-#: udata_front/theme/gouvfr/templates/dataset/display.html:122
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:89
+#: udata_front/theme/gouvfr/templates/dataset/display.html:124
 msgid "Author"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:92
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:94
 #, python-format
 msgid ""
 "This API has been published on the initiative and under the responsibility of"
@@ -771,71 +771,71 @@ msgid ""
 "                    %(author)s<br />Published on %(date)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:100
-#: udata_front/theme/gouvfr/templates/dataset/display.html:158
-#: udata_front/theme/gouvfr/templates/dataset/display.html:574
-#: udata_front/theme/gouvfr/templates/organization/display.html:345
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:102
+#: udata_front/theme/gouvfr/templates/dataset/display.html:160
+#: udata_front/theme/gouvfr/templates/dataset/display.html:576
+#: udata_front/theme/gouvfr/templates/organization/display.html:347
 msgid "Latest update"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:104
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:106
 msgid "Rate limiting"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:109
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:117
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:153
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:164
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:111
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:119
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:155
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:166
 msgid "Not documented"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:112
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:114
 msgid "Availability"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:115
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:117
 #, python-format
 msgid "%(availability)s last month"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:120
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:122
 msgid "Access"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:124
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:126
 msgid "Restricted"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:134
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:136
 msgid "Make an authorization request"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:140
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:142
 msgid "Opened"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:144
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:146
 msgid "API link"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:155
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:157
 msgid "Documentation link"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:178
-#: udata_front/theme/gouvfr/templates/reuse/display.html:171
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:180
+#: udata_front/theme/gouvfr/templates/reuse/display.html:173
 #, python-format
 msgid "%(num)d used dataset"
 msgid_plural "%(num)d used datasets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:188
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:190
 #, python-format
 msgid "No datasets on %(site)s are linked to this API."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataservice/display.html:203
+#: udata_front/theme/gouvfr/templates/dataservice/display.html:205
 msgid "There are no discussions for this API yet."
 msgstr ""
 
@@ -866,35 +866,35 @@ msgid_plural "<strong class=\"fr-mr-1v\">%(num)d</strong> favorites"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:17
+#: udata_front/theme/gouvfr/templates/dataset/display.html:18
 msgid "dataset"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:23
-#: udata_front/theme/gouvfr/templates/reuse/display.html:18
+#: udata_front/theme/gouvfr/templates/dataset/display.html:24
+#: udata_front/theme/gouvfr/templates/reuse/display.html:19
 #, python-format
 msgid "Explore with %(certifier)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:76
+#: udata_front/theme/gouvfr/templates/dataset/display.html:78
 msgid "This dataset is private and will not be visible by other users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:83
+#: udata_front/theme/gouvfr/templates/dataset/display.html:85
 msgid "This dataset has been deleted. This will be permanent in the next 24 hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:88
+#: udata_front/theme/gouvfr/templates/dataset/display.html:90
 msgid ""
 "This dataset has been archived automatically because it has been deleted from"
 " the remote platform."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:90
+#: udata_front/theme/gouvfr/templates/dataset/display.html:92
 msgid "This dataset has been archived."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:127
+#: udata_front/theme/gouvfr/templates/dataset/display.html:129
 #, python-format
 msgid ""
 "This dataset has been published on the initiative and under the "
@@ -903,13 +903,13 @@ msgid ""
 "%(update)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:139
+#: udata_front/theme/gouvfr/templates/dataset/display.html:141
 msgid ""
 "This dataset come from an external portal.&nbsp;<a href='{external_source}' "
 "rel='ugc nofollow noopener'>View the original source.</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:147
+#: udata_front/theme/gouvfr/templates/dataset/display.html:149
 msgid ""
 "This dataset is handled by the <a href='{geo_link}'>geo.data.gouv.fr</a> "
 "platform.\n"
@@ -919,141 +919,141 @@ msgid ""
 "geo.data.gouv.fr is available here.</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:163
-#: udata_front/theme/gouvfr/templates/dataset/display.html:539
+#: udata_front/theme/gouvfr/templates/dataset/display.html:165
+#: udata_front/theme/gouvfr/templates/dataset/display.html:541
 msgid "License"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:181
-#: udata_front/theme/gouvfr/templates/dataset/display.html:263
-#: udata_front/theme/gouvfr/templates/organization/display.html:78
-#: udata_front/theme/gouvfr/templates/organization/display.html:146
+#: udata_front/theme/gouvfr/templates/dataset/display.html:183
+#: udata_front/theme/gouvfr/templates/dataset/display.html:265
+#: udata_front/theme/gouvfr/templates/organization/display.html:80
+#: udata_front/theme/gouvfr/templates/organization/display.html:148
 msgid "In-page navigation"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:245
-#: udata_front/theme/gouvfr/templates/dataset/display.html:301
+#: udata_front/theme/gouvfr/templates/dataset/display.html:247
+#: udata_front/theme/gouvfr/templates/dataset/display.html:303
 msgid "Community resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:259
-#: udata_front/theme/gouvfr/templates/dataset/display.html:311
-#: udata_front/theme/gouvfr/templates/dataset/display.html:520
-#: udata_front/theme/gouvfr/templates/organization/display.html:142
-#: udata_front/theme/gouvfr/templates/organization/display.html:182
+#: udata_front/theme/gouvfr/templates/dataset/display.html:261
+#: udata_front/theme/gouvfr/templates/dataset/display.html:313
+#: udata_front/theme/gouvfr/templates/dataset/display.html:522
+#: udata_front/theme/gouvfr/templates/organization/display.html:144
+#: udata_front/theme/gouvfr/templates/organization/display.html:184
 msgid "Information"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:355
+#: udata_front/theme/gouvfr/templates/dataset/display.html:357
 #, python-format
 msgid "See the %(type)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:363
+#: udata_front/theme/gouvfr/templates/dataset/display.html:365
 msgid "There are no files for this dataset yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:371
+#: udata_front/theme/gouvfr/templates/dataset/display.html:373
 msgid "Add a file"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:392
+#: udata_front/theme/gouvfr/templates/dataset/display.html:394
 #, python-format
 msgid "%(num)d Reuse"
 msgid_plural "%(num)d Reuses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:397
+#: udata_front/theme/gouvfr/templates/dataset/display.html:399
 msgid "Add a reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:414
+#: udata_front/theme/gouvfr/templates/dataset/display.html:416
 msgid "There are no reuses for this dataset yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:421
+#: udata_front/theme/gouvfr/templates/dataset/display.html:423
 msgid "Publish a reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:427
-#: udata_front/theme/gouvfr/templates/organization/display.html:293
+#: udata_front/theme/gouvfr/templates/dataset/display.html:429
+#: udata_front/theme/gouvfr/templates/organization/display.html:295
 msgid "What's a reuse ?"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:446
+#: udata_front/theme/gouvfr/templates/dataset/display.html:448
 msgid "There are no discussions for this dataset yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:470
+#: udata_front/theme/gouvfr/templates/dataset/display.html:472
 msgid ""
 "These resources are published by the community and the producer isn't "
 "responsible for them."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:477
+#: udata_front/theme/gouvfr/templates/dataset/display.html:479
 #, python-format
 msgid "%(num)d Community resource"
 msgid_plural "%(num)d Community resources"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:492
+#: udata_front/theme/gouvfr/templates/dataset/display.html:494
 msgid "There are no community resources for this dataset yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:499
+#: udata_front/theme/gouvfr/templates/dataset/display.html:501
 msgid "Share your resources"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:505
+#: udata_front/theme/gouvfr/templates/dataset/display.html:507
 msgid "Learn more about the community"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:521
-#: udata_front/theme/gouvfr/templates/reuse/display.html:148
+#: udata_front/theme/gouvfr/templates/dataset/display.html:523
+#: udata_front/theme/gouvfr/templates/reuse/display.html:150
 msgid "Tags"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:547
-#: udata_front/theme/gouvfr/templates/organization/display.html:348
+#: udata_front/theme/gouvfr/templates/dataset/display.html:549
+#: udata_front/theme/gouvfr/templates/organization/display.html:350
 msgid "ID"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:551
+#: udata_front/theme/gouvfr/templates/dataset/display.html:553
 msgid "Remote source"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:557
+#: udata_front/theme/gouvfr/templates/dataset/display.html:559
 msgid "Temporality"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:559
+#: udata_front/theme/gouvfr/templates/dataset/display.html:561
 msgid "Creation"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:580
+#: udata_front/theme/gouvfr/templates/dataset/display.html:582
 msgid "Spatial coverage"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:583
-#: udata_front/theme/gouvfr/templates/dataset/display.html:590
+#: udata_front/theme/gouvfr/templates/dataset/display.html:585
+#: udata_front/theme/gouvfr/templates/dataset/display.html:592
 msgid "Territorial coverage"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:595
+#: udata_front/theme/gouvfr/templates/dataset/display.html:597
 msgid "Territorial coverage granularity"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:604
+#: udata_front/theme/gouvfr/templates/dataset/display.html:606
 msgid "Data schema"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:609
+#: udata_front/theme/gouvfr/templates/dataset/display.html:611
 msgid "The dataset files are following the schema: "
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:615
+#: udata_front/theme/gouvfr/templates/dataset/display.html:617
 msgid ""
 "Schemas allow to describe data models,\n"
 "                                discover how schemas improve your data "
@@ -1061,29 +1061,29 @@ msgid ""
 "                                on <a href=\"{url}\">schema.data.gouv.fr</a>"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:626
+#: udata_front/theme/gouvfr/templates/dataset/display.html:628
 #: udata_front/theme/gouvfr/templates/dataset/resource/card.html:132
 msgid "See schema documentation"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:639
+#: udata_front/theme/gouvfr/templates/dataset/display.html:641
 msgid "Extras"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:648
+#: udata_front/theme/gouvfr/templates/dataset/display.html:650
 msgid "See extras"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:667
+#: udata_front/theme/gouvfr/templates/dataset/display.html:669
 msgid "Harvest"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/dataset/display.html:676
+#: udata_front/theme/gouvfr/templates/dataset/display.html:678
 msgid "See harvest extras"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/followers.html:16
-#: udata_front/theme/gouvfr/templates/organization/display.html:25
+#: udata_front/theme/gouvfr/templates/organization/display.html:26
 #: udata_front/theme/gouvfr/templates/organization/list.html:25
 #: udata_front/theme/gouvfr/templates/reuse/list.html:44
 #: udata_front/theme/gouvfr/templates/user/followers.html:21
@@ -1119,13 +1119,13 @@ msgid "datasets"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/list.html:23
-#: udata_front/theme/gouvfr/templates/organization/display.html:353
-#: udata_front/theme/gouvfr/templates/reuse/display.html:157
+#: udata_front/theme/gouvfr/templates/organization/display.html:355
+#: udata_front/theme/gouvfr/templates/reuse/display.html:159
 msgid "Creation date"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/list.html:24
-#: udata_front/theme/gouvfr/templates/reuse/display.html:161
+#: udata_front/theme/gouvfr/templates/reuse/display.html:163
 msgid "Last update"
 msgstr ""
 
@@ -1147,14 +1147,14 @@ msgid "Search reuses"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/list.html:54
-#: udata_front/theme/gouvfr/templates/organization/display.html:220
+#: udata_front/theme/gouvfr/templates/organization/display.html:222
 msgid "Search for dataset"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/list.html:56
 #: udata_front/theme/gouvfr/templates/dataset/list.html:61
-#: udata_front/theme/gouvfr/templates/organization/display.html:222
-#: udata_front/theme/gouvfr/templates/organization/display.html:227
+#: udata_front/theme/gouvfr/templates/organization/display.html:224
+#: udata_front/theme/gouvfr/templates/organization/display.html:229
 #: udata_front/theme/gouvfr/templates/organization/list.html:37
 #: udata_front/theme/gouvfr/templates/organization/list.html:42
 #: udata_front/theme/gouvfr/templates/reuse/list.html:62
@@ -1164,7 +1164,7 @@ msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/list.html:67
 #: udata_front/theme/gouvfr/templates/macros/search.html:224
-#: udata_front/theme/gouvfr/templates/organization/display.html:233
+#: udata_front/theme/gouvfr/templates/organization/display.html:235
 #: udata_front/theme/gouvfr/templates/organization/list.html:48
 #: udata_front/theme/gouvfr/templates/post/subnav.html:13
 #: udata_front/theme/gouvfr/templates/reuse/list.html:73
@@ -1172,7 +1172,7 @@ msgid "Search"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/list.html:71
-#: udata_front/theme/gouvfr/templates/organization/display.html:237
+#: udata_front/theme/gouvfr/templates/organization/display.html:239
 #: udata_front/theme/gouvfr/templates/organization/list.html:52
 #: udata_front/theme/gouvfr/templates/reuse/list.html:101
 #, python-format
@@ -1646,8 +1646,8 @@ msgid "A new reuse of your dataset %(dataset)s has been published"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/mail/new_reuse.html:31
-#: udata_front/theme/gouvfr/templates/reuse/display.html:54
-#: udata_front/theme/gouvfr/templates/reuse/display.html:106
+#: udata_front/theme/gouvfr/templates/reuse/display.html:56
+#: udata_front/theme/gouvfr/templates/reuse/display.html:108
 msgid "See the reuse"
 msgstr ""
 
@@ -1733,58 +1733,58 @@ msgid_plural "<strong class=\"fr-mr-1v\">%(num)d</strong> datasets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:15
+#: udata_front/theme/gouvfr/templates/organization/display.html:16
 msgid "organization"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:23
+#: udata_front/theme/gouvfr/templates/organization/display.html:24
 #: udata_front/theme/gouvfr/templates/organization/list.html:23
 #: udata_front/theme/gouvfr/templates/reuse/list.html:42
 msgid "Newest"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:24
+#: udata_front/theme/gouvfr/templates/organization/display.html:25
 #: udata_front/theme/gouvfr/templates/organization/list.html:24
 #: udata_front/theme/gouvfr/templates/reuse/list.html:43
 msgid "Oldest"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:53
+#: udata_front/theme/gouvfr/templates/organization/display.html:55
 msgid "Modify organization"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:65
+#: udata_front/theme/gouvfr/templates/organization/display.html:67
 msgid ""
 "This organization has been deleted. This will be permanent in the next 24 "
 "hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:93
-#: udata_front/theme/gouvfr/templates/organization/display.html:153
+#: udata_front/theme/gouvfr/templates/organization/display.html:95
+#: udata_front/theme/gouvfr/templates/organization/display.html:155
 msgid "Presentation"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:251
+#: udata_front/theme/gouvfr/templates/organization/display.html:253
 msgid "This organization hasn't published any datasets yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:258
+#: udata_front/theme/gouvfr/templates/organization/display.html:260
 msgid "What's a dataset ?"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:286
+#: udata_front/theme/gouvfr/templates/organization/display.html:288
 msgid "This organization hasn't published any reuses yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:311
+#: udata_front/theme/gouvfr/templates/organization/display.html:313
 msgid "Members"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:323
+#: udata_front/theme/gouvfr/templates/organization/display.html:325
 msgid "Pending request to join this organization"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/organization/display.html:343
+#: udata_front/theme/gouvfr/templates/organization/display.html:345
 msgid "Technical details"
 msgstr ""
 
@@ -1876,42 +1876,42 @@ msgstr ""
 msgid " by "
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:10
+#: udata_front/theme/gouvfr/templates/reuse/display.html:11
 msgid "reuse"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:79
+#: udata_front/theme/gouvfr/templates/reuse/display.html:81
 msgid "This reuse is private and will not be visible by other users"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:86
+#: udata_front/theme/gouvfr/templates/reuse/display.html:88
 msgid "This reuse has been deleted. This will be permanent in the next 24 hours"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:134
+#: udata_front/theme/gouvfr/templates/reuse/display.html:136
 msgid "Topic"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:141
+#: udata_front/theme/gouvfr/templates/reuse/display.html:143
 msgid "Type"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:189
+#: udata_front/theme/gouvfr/templates/reuse/display.html:191
 msgid "There are no discussions for this reuse yet."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:204
+#: udata_front/theme/gouvfr/templates/reuse/display.html:206
 #, python-format
 msgid "%(num)d reuse from the same creator"
 msgid_plural "%(num)d reuses from the same creator"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:215
+#: udata_front/theme/gouvfr/templates/reuse/display.html:217
 msgid "Reuses from the same creator"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/reuse/display.html:220
+#: udata_front/theme/gouvfr/templates/reuse/display.html:222
 msgid "There are no other reuses from this creator."
 msgstr ""
 
@@ -2013,7 +2013,7 @@ msgstr ""
 
 #: udata_front/theme/gouvfr/templates/security/change_email.html:15
 #: udata_front/theme/gouvfr/templates/security/change_password.html:15
-#: udata_front/theme/gouvfr/templates/security/forgot_password.html:15
+#: udata_front/theme/gouvfr/templates/security/forgot_password.html:16
 #: udata_front/theme/gouvfr/templates/security/login_user.html:14
 #: udata_front/theme/gouvfr/templates/security/register_user.html:23
 #: udata_front/theme/gouvfr/templates/security/reset_password.html:13
@@ -2034,17 +2034,26 @@ msgid ""
 "password below."
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/security/forgot_password.html:10
-#: udata_front/theme/gouvfr/templates/security/forgot_password.html:17
+#: udata_front/theme/gouvfr/templates/security/forgot_password.html:11
+#: udata_front/theme/gouvfr/templates/security/forgot_password.html:44
 #: udata_front/theme/gouvfr/templates/security/reset_password.html:11
 #: udata_front/theme/gouvfr/templates/security/reset_password.html:15
 msgid "Reset Password"
 msgstr ""
 
-#: udata_front/theme/gouvfr/templates/security/forgot_password.html:12
+#: udata_front/theme/gouvfr/templates/security/forgot_password.html:13
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
 "instructions for setting a new one."
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/security/forgot_password.html:22
+msgid "Javascript is required to use this page correctly."
+msgstr ""
+
+#: udata_front/theme/gouvfr/templates/security/forgot_password.html:29
+#: udata_front/theme/gouvfr/templates/security/register_user.html:48
+msgid "Retype the characters from the picture"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/security/login_user.html:30
@@ -2098,10 +2107,6 @@ msgstr ""
 msgid ""
 "I have read and accept <a href=\"%(url)s\"> the terms and conditions of the "
 "service.</a>"
-msgstr ""
-
-#: udata_front/theme/gouvfr/templates/security/register_user.html:48
-msgid "Retype the characters from the picture"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/security/send_confirmation.html:10

--- a/vue-i18n-extract.config.js
+++ b/vue-i18n-extract.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  "vueFiles": "{udata_front,udata-front-plugins-helper}/**/{assets/js,src}/**/*.{js,vue}",
+  "vueFiles": "udata_front/**/assets/js/**/*.{js,ts,vue}",
   "languageFiles": "udata_front/theme/**/js/locales/**/*.?(json|yaml|yml|js)",
   "exclude": [],
   "output": false,


### PR DESCRIPTION
This PR adds missing translations and update the `vue-i18n-extract` config file now that udata-front-plugins-helper doesn't contain any vue files.