### PR TITLE
Fix resource translation

### DIFF
--- a/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
+++ b/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix resource translation [#468](https://github.com/datagouv/udata-front/pull/468)
 
 ## 1.1.1 (2024-07-29)
 

--- a/udata_front/theme/gouvfr/datagouv-components/package-lock.json
+++ b/udata_front/theme/gouvfr/datagouv-components/package-lock.json
@@ -45,7 +45,7 @@
         "vite": "^4.5.2",
         "vite-plugin-dts": "^3.6.3",
         "vue-content-loader": "^2.0.1",
-        "vue-i18n": "^9.8.0",
+        "vue-i18n": "^9.13.1",
         "vue-i18n-extract": "^2.0.7",
         "vue-router": "^4.2.5"
       },
@@ -2233,12 +2233,13 @@
       }
     },
     "node_modules/@intlify/core-base": {
-      "version": "9.8.0",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.13.1.tgz",
+      "integrity": "sha512-+bcQRkJO9pcX8d0gel9ZNfrzU22sZFSA0WVhfXrf5jdJOS24a+Bp8pozuS9sBI9Hk/tGz83pgKfmqcn/Ci7/8w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@intlify/message-compiler": "9.8.0",
-        "@intlify/shared": "9.8.0"
+        "@intlify/message-compiler": "9.13.1",
+        "@intlify/shared": "9.13.1"
       },
       "engines": {
         "node": ">= 16"
@@ -2248,11 +2249,12 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "9.8.0",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.13.1.tgz",
+      "integrity": "sha512-SKsVa4ajYGBVm7sHMXd5qX70O2XXjm55zdZB3VeMFCvQyvLew/dLvq3MqnaIsTMF1VkkOb9Ttr6tHcMlyPDL9w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@intlify/shared": "9.8.0",
+        "@intlify/shared": "9.13.1",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -2263,9 +2265,10 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "9.8.0",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.13.1.tgz",
+      "integrity": "sha512-u3b6BKGhE6j/JeRU6C/RL2FgyJfy6LakbtfeVF8fJXURpZZTzfh3e05J0bu0XPw447Q6/WUp3C4ajv4TMS4YsQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -12737,12 +12740,13 @@
       }
     },
     "node_modules/vue-i18n": {
-      "version": "9.8.0",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.13.1.tgz",
+      "integrity": "sha512-mh0GIxx0wPtPlcB1q4k277y0iKgo25xmDPWioVVYanjPufDBpvu5ySTjP5wOrSvlYQ2m1xI+CFhGdauv/61uQg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@intlify/core-base": "9.8.0",
-        "@intlify/shared": "9.8.0",
+        "@intlify/core-base": "9.13.1",
+        "@intlify/shared": "9.13.1",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {

--- a/udata_front/theme/gouvfr/datagouv-components/package.json
+++ b/udata_front/theme/gouvfr/datagouv-components/package.json
@@ -69,7 +69,7 @@
     "vite": "^4.5.2",
     "vite-plugin-dts": "^3.6.3",
     "vue-content-loader": "^2.0.1",
-    "vue-i18n": "^9.8.0",
+    "vue-i18n": "^9.13.1",
     "vue-i18n-extract": "^2.0.7",
     "vue-router": "^4.2.5"
   },

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/ResourceAccordion/Preview/Preview.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/ResourceAccordion/Preview/Preview.vue
@@ -8,14 +8,14 @@
     </div>
     <Loader v-else-if="loading" />
     <template v-else>
-      <div class="bg-blue-100 text-blue-400 fr-hidden flex-md fr-p-2w fr-grid-row--middle">
-        <div class="fr-px-1w fr-mr-2w" v-html="franceSvg">
+      <div class="bg-blue-100 text-blue-400 fr-hidden flex-md fr-p-2w fr-grid-row--middle fr-grid-row--gutters">
+        <div class="fr-col-auto" v-html="franceSvg">
         </div>
-        <div class="fr-mx-2w">
+        <div class="fr-col">
           <p class="fr-text--bold fr-m-0">{{ t("Explore data in detail") }}</p>
           <p class="fr-text--sm fr-m-0 f-italic">{{ t("Use our tool to get an overview of data, learn about different columns or perform filters and sorts.") }}</p>
         </div>
-        <p class="fr-ml-auto fr-my-0">
+        <p class="fr-col-auto fr-my-0">
           <a :href="resource.preview_url" class="fr-btn fr-btn--icon-right fr-icon-external-link-fill">
             {{ t("Explore data") }}
           </a>

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/ResourceAccordion/Preview/Preview.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/ResourceAccordion/Preview/Preview.vue
@@ -8,18 +8,20 @@
     </div>
     <Loader v-else-if="loading" />
     <template v-else>
-      <div class="bg-blue-100 text-blue-400 fr-hidden flex-md fr-p-2w fr-grid-row--middle fr-grid-row--gutters">
-        <div class="fr-col-auto" v-html="franceSvg">
+      <div class="bg-blue-100 text-blue-400 fr-hidden fr-unhidden-md fr-p-2w">
+        <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
+          <div class="fr-col-auto" v-html="franceSvg">
+          </div>
+          <div class="fr-col">
+            <p class="fr-text--bold fr-m-0">{{ t("Explore data in detail") }}</p>
+            <p class="fr-text--sm fr-m-0 f-italic">{{ t("Use our tool to get an overview of data, learn about different columns or perform filters and sorts.") }}</p>
+          </div>
+          <p class="fr-col-auto fr-my-0">
+            <a :href="resource.preview_url" class="fr-btn fr-btn--icon-right fr-icon-external-link-fill">
+              {{ t("Explore data") }}
+            </a>
+          </p>
         </div>
-        <div class="fr-col">
-          <p class="fr-text--bold fr-m-0">{{ t("Explore data in detail") }}</p>
-          <p class="fr-text--sm fr-m-0 f-italic">{{ t("Use our tool to get an overview of data, learn about different columns or perform filters and sorts.") }}</p>
-        </div>
-        <p class="fr-col-auto fr-my-0">
-          <a :href="resource.preview_url" class="fr-btn fr-btn--icon-right fr-icon-external-link-fill">
-            {{ t("Explore data") }}
-          </a>
-        </p>
       </div>
       <div class="fr-table fr-table--no-background fr-p-0 fr-pt-0-5v fr-m-0">
         <table class="fr-mb-3w">


### PR DESCRIPTION
This PR fixes the translation `Use our tool to get an overview of data, learn about different columns or perform filters and sorts.` not found.

It upgrades the `vue-i18n` to fix the regression (see https://github.com/intlify/vue-i18n/issues/1717 for reference).

There is also a slight visual fix to prevent the `explore data` button to show its content on 2 lines.