### PR TITLE
Fix translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - update dependencies following updated dependencies on udata [#470](https://github.com/datagouv/udata-front/pull/470)
+- update `@datagouv/components` and `vue-i18n` and fix report translation [#471](https://github.com/datagouv/udata-front/pull/471)
 
 ## 5.1.0 (2024-07-30)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.4",
       "license": "LGPL-2.1-only",
       "dependencies": {
-        "@datagouv/components": "^1.1.1",
+        "@datagouv/components": "^1.1.2",
         "@datagouv/select-a11y": "^3.6.1",
         "leaflet": "^1.9.4"
       },
@@ -2291,9 +2291,9 @@
       }
     },
     "node_modules/@datagouv/components": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@datagouv/components/-/components-1.1.1.tgz",
-      "integrity": "sha512-WdDvnHL+H28RrOy/jJ4VeC/1BJAqnBYaq/57NO/55gVL7wBInf4U13lh2rvxGhpRerpsYPlrHu6vAQw6TM/fMg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@datagouv/components/-/components-1.1.2.tgz",
+      "integrity": "sha512-58f5H4iIpRwD1Z7rWdQeTZMzbFhx+EpYBYHJMgLndRifIvTop1Wb9sNxokqIEbjyEqy3F1WaObYvaXDYF4dVYg==",
       "dependencies": {
         "vue": "^3.3.8"
       },
@@ -23640,9 +23640,9 @@
       }
     },
     "@datagouv/components": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@datagouv/components/-/components-1.1.1.tgz",
-      "integrity": "sha512-WdDvnHL+H28RrOy/jJ4VeC/1BJAqnBYaq/57NO/55gVL7wBInf4U13lh2rvxGhpRerpsYPlrHu6vAQw6TM/fMg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@datagouv/components/-/components-1.1.2.tgz",
+      "integrity": "sha512-58f5H4iIpRwD1Z7rWdQeTZMzbFhx+EpYBYHJMgLndRifIvTop1Wb9sNxokqIEbjyEqy3F1WaObYvaXDYF4dVYg==",
       "requires": {
         "vue": "^3.3.8"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "vite": "^4.5.2",
         "vue": "^3.4.21",
         "vue-content-loader": "^2.0.1",
-        "vue-i18n": "^9.8.0",
+        "vue-i18n": "^9.13.1",
         "vue-i18n-extract": "^2.0.7",
         "vue-router": "^4.2.5",
         "vue3-datepicker": "^0.4.0"
@@ -2533,13 +2533,13 @@
       }
     },
     "node_modules/@intlify/core-base": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.8.0.tgz",
-      "integrity": "sha512-UxaSZVZ1DwqC/CltUZrWZNaWNhfmKtfyV4BJSt/Zt4Or/fZs1iFj0B+OekYk1+MRHfIOe3+x00uXGQI4PbO/9g==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.13.1.tgz",
+      "integrity": "sha512-+bcQRkJO9pcX8d0gel9ZNfrzU22sZFSA0WVhfXrf5jdJOS24a+Bp8pozuS9sBI9Hk/tGz83pgKfmqcn/Ci7/8w==",
       "dev": true,
       "dependencies": {
-        "@intlify/message-compiler": "9.8.0",
-        "@intlify/shared": "9.8.0"
+        "@intlify/message-compiler": "9.13.1",
+        "@intlify/shared": "9.13.1"
       },
       "engines": {
         "node": ">= 16"
@@ -2549,12 +2549,12 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.8.0.tgz",
-      "integrity": "sha512-McnYWhcoYmDJvssVu6QGR0shqlkJuL1HHdi5lK7fNqvQqRYaQ4lSLjYmZxwc8tRNMdIe9/KUKfyPxU9M6yCtNQ==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.13.1.tgz",
+      "integrity": "sha512-SKsVa4ajYGBVm7sHMXd5qX70O2XXjm55zdZB3VeMFCvQyvLew/dLvq3MqnaIsTMF1VkkOb9Ttr6tHcMlyPDL9w==",
       "dev": true,
       "dependencies": {
-        "@intlify/shared": "9.8.0",
+        "@intlify/shared": "9.13.1",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -2565,9 +2565,9 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.8.0.tgz",
-      "integrity": "sha512-TmgR0RCLjzrSo+W3wT0ALf9851iFMlVI9EYNGeWvZFUQTAJx0bvfsMlPdgVtV1tDNRiAfhkFsMKu6jtUY1ZLKQ==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.13.1.tgz",
+      "integrity": "sha512-u3b6BKGhE6j/JeRU6C/RL2FgyJfy6LakbtfeVF8fJXURpZZTzfh3e05J0bu0XPw447Q6/WUp3C4ajv4TMS4YsQ==",
       "dev": true,
       "engines": {
         "node": ">= 16"
@@ -21480,13 +21480,13 @@
       }
     },
     "node_modules/vue-i18n": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.8.0.tgz",
-      "integrity": "sha512-Izho+6PYjejsTq2mzjcRdBZ5VLRQoSuuexvR8029h5CpN03FYqiqBrShMyf2I1DKkN6kw/xmujcbvC+4QybpsQ==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.13.1.tgz",
+      "integrity": "sha512-mh0GIxx0wPtPlcB1q4k277y0iKgo25xmDPWioVVYanjPufDBpvu5ySTjP5wOrSvlYQ2m1xI+CFhGdauv/61uQg==",
       "dev": true,
       "dependencies": {
-        "@intlify/core-base": "9.8.0",
-        "@intlify/shared": "9.8.0",
+        "@intlify/core-base": "9.13.1",
+        "@intlify/shared": "9.13.1",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {
@@ -23811,29 +23811,29 @@
       }
     },
     "@intlify/core-base": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.8.0.tgz",
-      "integrity": "sha512-UxaSZVZ1DwqC/CltUZrWZNaWNhfmKtfyV4BJSt/Zt4Or/fZs1iFj0B+OekYk1+MRHfIOe3+x00uXGQI4PbO/9g==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.13.1.tgz",
+      "integrity": "sha512-+bcQRkJO9pcX8d0gel9ZNfrzU22sZFSA0WVhfXrf5jdJOS24a+Bp8pozuS9sBI9Hk/tGz83pgKfmqcn/Ci7/8w==",
       "dev": true,
       "requires": {
-        "@intlify/message-compiler": "9.8.0",
-        "@intlify/shared": "9.8.0"
+        "@intlify/message-compiler": "9.13.1",
+        "@intlify/shared": "9.13.1"
       }
     },
     "@intlify/message-compiler": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.8.0.tgz",
-      "integrity": "sha512-McnYWhcoYmDJvssVu6QGR0shqlkJuL1HHdi5lK7fNqvQqRYaQ4lSLjYmZxwc8tRNMdIe9/KUKfyPxU9M6yCtNQ==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.13.1.tgz",
+      "integrity": "sha512-SKsVa4ajYGBVm7sHMXd5qX70O2XXjm55zdZB3VeMFCvQyvLew/dLvq3MqnaIsTMF1VkkOb9Ttr6tHcMlyPDL9w==",
       "dev": true,
       "requires": {
-        "@intlify/shared": "9.8.0",
+        "@intlify/shared": "9.13.1",
         "source-map-js": "^1.0.2"
       }
     },
     "@intlify/shared": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.8.0.tgz",
-      "integrity": "sha512-TmgR0RCLjzrSo+W3wT0ALf9851iFMlVI9EYNGeWvZFUQTAJx0bvfsMlPdgVtV1tDNRiAfhkFsMKu6jtUY1ZLKQ==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.13.1.tgz",
+      "integrity": "sha512-u3b6BKGhE6j/JeRU6C/RL2FgyJfy6LakbtfeVF8fJXURpZZTzfh3e05J0bu0XPw447Q6/WUp3C4ajv4TMS4YsQ==",
       "dev": true
     },
     "@intlify/unplugin-vue-i18n": {
@@ -37086,13 +37086,13 @@
       }
     },
     "vue-i18n": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.8.0.tgz",
-      "integrity": "sha512-Izho+6PYjejsTq2mzjcRdBZ5VLRQoSuuexvR8029h5CpN03FYqiqBrShMyf2I1DKkN6kw/xmujcbvC+4QybpsQ==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.13.1.tgz",
+      "integrity": "sha512-mh0GIxx0wPtPlcB1q4k277y0iKgo25xmDPWioVVYanjPufDBpvu5ySTjP5wOrSvlYQ2m1xI+CFhGdauv/61uQg==",
       "dev": true,
       "requires": {
-        "@intlify/core-base": "9.8.0",
-        "@intlify/shared": "9.8.0",
+        "@intlify/core-base": "9.13.1",
+        "@intlify/shared": "9.13.1",
         "@vue/devtools-api": "^6.5.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "vite": "^4.5.2",
     "vue": "^3.4.21",
     "vue-content-loader": "^2.0.1",
-    "vue-i18n": "^9.8.0",
+    "vue-i18n": "^9.13.1",
     "vue-i18n-extract": "^2.0.7",
     "vue-router": "^4.2.5",
     "vue3-datepicker": "^0.4.0"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "license": "LGPL-2.1-only",
   "dependencies": {
-    "@datagouv/components": "^1.1.1",
+    "@datagouv/components": "^1.1.2",
     "@datagouv/select-a11y": "^3.6.1",
     "leaflet": "^1.9.4"
   },

--- a/udata_front/theme/gouvfr/assets/js/components/Report/ReportModal.vue
+++ b/udata_front/theme/gouvfr/assets/js/components/Report/ReportModal.vue
@@ -74,7 +74,7 @@
                     :hasError="fieldHasError('message')"
                     :errorText="getErrorText('message')"
                     v-model="form.message"
-                    :placeholder="t('Reason of your report.\nDon\'t include any personal data.')"
+                    :placeholder="t(`Reason of your report.{newline}Don't include any personal data.`)"
                   />
                 </div>
                 <div class="fr-modal__footer">

--- a/udata_front/theme/gouvfr/assets/js/locales/de.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/de.json
@@ -449,7 +449,7 @@
   "Please only report in case of serious concern.": "Please only report in case of serious concern.",
   "See our usage policy": "See our usage policy",
   "Report reason": "Report reason",
-  "Reason of your report.\\nDon\\'t include any personal data.": "Reason of your report.\\nDon\\'t include any personal data.",
+  "Reason of your report.{newline}Don't include any personal data.": "Reason of your report.\nDon't include any personal data.",
   "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.": "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.",
   "Edit profile": "Edit profile",
   "Save": "Save",

--- a/udata_front/theme/gouvfr/assets/js/locales/en.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/en.json
@@ -449,7 +449,7 @@
   "Please only report in case of serious concern.": "Please only report in case of serious concern.",
   "See our usage policy": "See our usage policy",
   "Report reason": "Report reason",
-  "Reason of your report.\\nDon\\'t include any personal data.": "Reason of your report.\\nDon\\'t include any personal data.",
+  "Reason of your report.{newline}Don't include any personal data.": "Reason of your report.\nDon't include any personal data.",
   "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.": "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.",
   "Edit profile": "Edit profile",
   "Save": "Save",

--- a/udata_front/theme/gouvfr/assets/js/locales/es.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/es.json
@@ -449,7 +449,7 @@
   "Please only report in case of serious concern.": "Please only report in case of serious concern.",
   "See our usage policy": "See our usage policy",
   "Report reason": "Report reason",
-  "Reason of your report.\\nDon\\'t include any personal data.": "Reason of your report.\\nDon\\'t include any personal data.",
+  "Reason of your report.{newline}Don't include any personal data.": "Reason of your report.\nDon't include any personal data.",
   "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.": "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.",
   "Edit profile": "Edit profile",
   "Save": "Save",

--- a/udata_front/theme/gouvfr/assets/js/locales/fr.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/fr.json
@@ -449,7 +449,7 @@
   "Please only report in case of serious concern.": "Merci de ne signaler qu'en cas d'inquiétude sérieuse.",
   "See our usage policy": "Voir nos modalités d'utilisation",
   "Report reason": "Raison du signalement",
-  "Reason of your report.\\nDon\\'t include any personal data.": "Raison de votre signalement.\\nN\\'indiquez pas de données personnelles.",
+  "Reason of your report.{newline}Don't include any personal data.": "Raison de votre signalement.\nN'indiquez pas de données personnelles.",
   "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.": "L'équipe de {site} examinera le contenu pour déterminer si celui-ci enfreint nos {markup}. Merci pour votre aide.",
   "Edit profile": "Editer le profil",
   "Save": "Sauvegarder",

--- a/udata_front/theme/gouvfr/assets/js/locales/it.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/it.json
@@ -449,7 +449,7 @@
   "Please only report in case of serious concern.": "Please only report in case of serious concern.",
   "See our usage policy": "See our usage policy",
   "Report reason": "Report reason",
-  "Reason of your report.\\nDon\\'t include any personal data.": "Reason of your report.\\nDon\\'t include any personal data.",
+  "Reason of your report.{newline}Don't include any personal data.": "Reason of your report.\nDon't include any personal data.",
   "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.": "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.",
   "Edit profile": "Edit profile",
   "Save": "Save",

--- a/udata_front/theme/gouvfr/assets/js/locales/pt.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/pt.json
@@ -449,7 +449,7 @@
   "Please only report in case of serious concern.": "Please only report in case of serious concern.",
   "See our usage policy": "See our usage policy",
   "Report reason": "Report reason",
-  "Reason of your report.\\nDon\\'t include any personal data.": "Reason of your report.\\nDon\\'t include any personal data.",
+  "Reason of your report.{newline}Don't include any personal data.": "Reason of your report.\nDon't include any personal data.",
   "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.": "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.",
   "Edit profile": "Edit profile",
   "Save": "Save",

--- a/udata_front/theme/gouvfr/assets/js/locales/sr.json
+++ b/udata_front/theme/gouvfr/assets/js/locales/sr.json
@@ -449,7 +449,7 @@
   "Please only report in case of serious concern.": "Please only report in case of serious concern.",
   "See our usage policy": "See our usage policy",
   "Report reason": "Report reason",
-  "Reason of your report.\\nDon\\'t include any personal data.": "Reason of your report.\\nDon\\'t include any personal data.",
+  "Reason of your report.{newline}Don't include any personal data.": "Reason of your report.\nDon't include any personal data.",
   "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.": "{site} team will examine the content to check if it breaks our {markup}. Thanks for your help.",
   "Edit profile": "Edit profile",
   "Save": "Save",


### PR DESCRIPTION
Fixes reports translation, upgrades vue-i18n and use newest datagouv/component release.

See [components release v1.1.2](https://github.com/datagouv/udata-front/releases/tag/%40datagouv%2Fcomponents%401.1.2) for more details.