### PR TITLE
Improve organization type logic

### DIFF
--- a/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
+++ b/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add new resources_dowloads metric to Dataset type [#474](https://github.com/datagouv/udata-front/pull/474)
+- Improve organization type logic [#475](https://github.com/datagouv/udata-front/pull/475)
 
 ## 1.1.2 (2024-08-01)
 

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DatasetCard/DatasetCard.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DatasetCard/DatasetCard.stories.ts
@@ -97,7 +97,14 @@ const dataset: DatasetV2 = {
     page: "https://demo.data.gouv.fr/fr/organizations/test-meteo-france/",
     business_number_id: "",
     description: "",
-    badges: [],
+    badges: [
+      {
+        "kind": "public-service"
+      },
+      {
+        "kind": "certified"
+      }
+    ],
     name: "Météo France",
     slug: "test-meteo-france",
     uri: "https://demo.data.gouv.fr/api/1/organizations/test-meteo-france/",

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerType.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerType.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
 import { OwnerType } from '.';
-import { ASSOCIATION, COMPANY, LOCAL_AUTHORITY, PUBLIC_SERVICE } from '../../composables/organizations/useOrganizationType';
+import { ASSOCIATION, COMPANY, LOCAL_AUTHORITY, OTHER, PUBLIC_SERVICE } from '../../composables/organizations/useOrganizationType';
 
 const meta = {
   title: "Components/Owners/Owner Type",
@@ -79,5 +79,18 @@ export const CompanyOwnerType: StoryObj<typeof meta> = {
   }),
   args: {
     type: COMPANY,
+  }
+};
+
+export const OtherOwnerType: StoryObj<typeof meta> = {
+  render: (args) => ({
+    components: { OwnerType },
+    setup() {
+      return { args };
+    },
+    template: '<OwnerType v-bind="args" />',
+  }),
+  args: {
+    type: OTHER,
   }
 };

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerType.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerType.vue
@@ -7,7 +7,7 @@
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import OwnerTypeIcon from "./OwnerTypeIcon.vue";
-import { ASSOCIATION, COMPANY, LOCAL_AUTHORITY, PUBLIC_SERVICE, USER, type OrganizationTypes, type UserType } from "../../composables/organizations/useOrganizationType";
+import { ASSOCIATION, COMPANY, LOCAL_AUTHORITY, OTHER, PUBLIC_SERVICE, USER, type OrganizationTypes, type UserType } from "../../composables/organizations/useOrganizationType";
 import { throwOnNever } from "../../helpers/throwOnNever";
 
 const props = defineProps<{
@@ -26,6 +26,8 @@ const { t } = useI18n();
       return t("Association");
     case COMPANY:
       return t('Company');
+      case OTHER:
+      return t('Other');
     case USER:
       return t("User");
     default:

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerTypeIcon.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerTypeIcon.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
 import OwnerTypeIcon from './OwnerTypeIcon.vue';
-import { ASSOCIATION, COMPANY, LOCAL_AUTHORITY, PUBLIC_SERVICE } from '../../composables/organizations/useOrganizationType';
+import { ASSOCIATION, COMPANY, LOCAL_AUTHORITY, OTHER, PUBLIC_SERVICE } from '../../composables/organizations/useOrganizationType';
 
 const meta = {
   title: "Components/Owners/Internals/Owner Type Icon",
@@ -79,5 +79,18 @@ export const CompanyOwnerTypeIcon: StoryObj<typeof meta> = {
   }),
   args: {
     type: COMPANY,
+  }
+};
+
+export const OtherTypeIcon: StoryObj<typeof meta> = {
+  render: (args) => ({
+    components: { OwnerTypeIcon },
+    setup() {
+      return { args };
+    },
+    template: '<OwnerTypeIcon v-bind="args" />',
+  }),
+  args: {
+    type: OTHER,
   }
 };

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerTypeIcon.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerTypeIcon.vue
@@ -1,11 +1,11 @@
 <template>
-  <Vicon :name="icon"/>
+  <Vicon v-if="icon" :name="icon"/>
 </template>
 <script setup lang="ts">
 import { computed } from "vue";
 import { OhVueIcon as Vicon, addIcons } from "oh-vue-icons";
 import { RiBankLine, RiBuilding2Line, RiCommunityLine, RiGovernmentLine, RiUserLine } from "oh-vue-icons/icons";
-import { ASSOCIATION, COMPANY, LOCAL_AUTHORITY, PUBLIC_SERVICE, USER, type OrganizationTypes, type UserType } from "../../composables/organizations/useOrganizationType";
+import { ASSOCIATION, COMPANY, LOCAL_AUTHORITY, OTHER, PUBLIC_SERVICE, USER, type OrganizationTypes, type UserType } from "../../composables/organizations/useOrganizationType";
 import { throwOnNever } from "../../helpers/throwOnNever";
 
 addIcons(RiBankLine, RiBuilding2Line, RiCommunityLine, RiGovernmentLine, RiUserLine);
@@ -26,6 +26,8 @@ const icon = computed(() => {
       return "ri-building-2-line";
     case USER:
       return "ri-user-line";
+    case OTHER:
+      return "";
     default:
       return throwOnNever(props.type, `Unknown type ${props.type}`);
   }

--- a/udata_front/theme/gouvfr/datagouv-components/src/composables/organizations/useOrganizationType.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/composables/organizations/useOrganizationType.ts
@@ -5,9 +5,10 @@ export const PUBLIC_SERVICE = "public-service";
 export const ASSOCIATION = "Association";
 export const COMPANY = "Company";
 export const LOCAL_AUTHORITY = "Local authority";
+export const OTHER = "other";
 export const USER = "user";
 
-export type OrganizationTypes = typeof PUBLIC_SERVICE | typeof ASSOCIATION | typeof COMPANY | typeof LOCAL_AUTHORITY;
+export type OrganizationTypes = typeof PUBLIC_SERVICE | typeof ASSOCIATION | typeof COMPANY | typeof LOCAL_AUTHORITY | typeof OTHER;
 
 export type UserType = typeof USER;
 
@@ -33,15 +34,18 @@ export default function useOrganizationType(organizationRef: MaybeRefOrGetter<Or
   const isPublicService = computed(() => isType(organizationRef, PUBLIC_SERVICE));
   const isAssociation = computed(() => isType(organizationRef, ASSOCIATION));
   const isLocalAuthority = computed(() => isType(organizationRef, LOCAL_AUTHORITY));
+  const isCompany = computed(() => isType(organizationRef, COMPANY));
   const type = computed(() => {
-    if(isPublicService.value) {
+    if (isLocalAuthority.value) {
+      return LOCAL_AUTHORITY;
+    } else if(isPublicService.value) {
       return PUBLIC_SERVICE;
     } else if(isAssociation.value) {
       return ASSOCIATION;
-    } else if (isLocalAuthority.value) {
-      return LOCAL_AUTHORITY;
-    } else {
+    } else if(isCompany.value) {
       return COMPANY;
+    } else {
+      return OTHER;
     }
   });
   return {


### PR DESCRIPTION
This PR changes the detection order of type to show `local authority` even for legacy cases with both `public service` and `local authority`.

It also adds a new `other` type without icon that shouldn't be shown on the organization page.