### PR TITLE
Always show authorization_request_url if present (even on open API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - show contact point in dataset and dataservice page [#479](https://github.com/datagouv/udata-front/pull/479)
+- always show authorization_request_url if present (even on open API) [#481](https://github.com/datagouv/udata-front/pull/481)
 
 ## 5.1.2 (2024-08-01)
 

--- a/udata_front/theme/gouvfr/templates/dataservice/display.html
+++ b/udata_front/theme/gouvfr/templates/dataservice/display.html
@@ -124,10 +124,15 @@
             </p>
             <h2 class="subtitle fr-mt-3v fr-mb-1v">{{ _('Access') }}</h2>
             <div class="fr-text--sm fr-mt-0 fr-mb-3v">
-            {% if dataservice.is_restricted %}
-                <p class="fr-badge fr-badge--warning fr-badge--no-icon">
-                    {{ _('Restricted') }}
-                </p>
+                {% if dataservice.is_restricted %}
+                    <p class="fr-badge fr-badge--warning fr-badge--no-icon">
+                        {{ _('Restricted') }}
+                    </p>
+                {% else %}
+                    <p class="fr-badge fr-badge--success fr-badge--no-icon">
+                        {{ _('Opened') }}
+                    </p>
+                {% endif %}
                 {% if dataservice.authorization_request_url %}
                     <p class="fr-m-0">
                         <a
@@ -140,11 +145,6 @@
                         </a>
                     </p>
                 {% endif %}
-            {% else %}
-                <p class="fr-badge fr-badge--success fr-badge--no-icon">
-                    {{ _('Opened') }}
-                </p>
-            {% endif %}
             </div>
             <h2 class="subtitle fr-mt-3v fr-mb-1v">{{ _('API link') }}</h2>
             <p class="fr-text--sm fr-mt-0 fr-mb-3v text-overflow-ellipsis">


### PR DESCRIPTION
Fix https://github.com/datagouv/data.gouv.fr/issues/1387