### PR TITLE
Fixes after release

### DIFF
--- a/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
+++ b/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Reduce organization type icon [#483](https://github.com/datagouv/udata-front/pull/483)
 
 ## 1.2.0 (2024-08-21)
 

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.stories.ts
@@ -98,7 +98,7 @@ const dataservice: Dataservice = {
   self_api_url: "",
   self_web_url: "",
   slug: "",
-  tags: null,
+  tags: [],
   title: "That Awesome API",
 };
 
@@ -126,6 +126,24 @@ export const SimpleDataserviceCard: StoryObj<typeof meta> = {
     template: `<DataserviceCard v-bind="args"/>`,
   }),
   args,
+};
+
+
+export const DataserviceWithoutAvailabilityCard: StoryObj<typeof meta> = {
+  render: (args) => ({
+    components: { DataserviceCard },
+    setup() {
+      return { args };
+    },
+    template: `<DataserviceCard v-bind="args"/>`,
+  }),
+  args: {
+    ...args,
+    dataservice: {
+      ...args.dataservice,
+      availability: null,
+    }
+  },
 };
 
 export const DataserviceCardWithoutDescription: StoryObj<typeof meta> = {

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.vue
@@ -39,7 +39,14 @@
     <p class="fr-text--sm text-mention-grey fr-my-0 fr-mt-1v">
       <span class="fr-icon-information-line fr-icon--sm text-grey-380"></span>
       {{ t('Availability :') }}
-      <span class="text-grey-400">{{ t('{n}%', dataservice.availability) }}</span>
+      <span class="text-grey-400">
+        <template v-if="dataservice.availability">
+          {{ t('{n}%', dataservice.availability) }}
+        </template>
+        <template v-else>
+          {{ t('unknown') }}
+        </template>
+      </span>
     </p>
     <p class="fr-text--sm fr-mt-1w fr-mb-0 overflow-wrap-anywhere" v-if="showDescription">{{ excerpt(dataservice.description, 160) }}</p>
   </article>

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerTypeIcon.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerTypeIcon.stories.ts
@@ -3,7 +3,7 @@ import OwnerTypeIcon from './OwnerTypeIcon.vue';
 import { ASSOCIATION, COMPANY, LOCAL_AUTHORITY, OTHER, PUBLIC_SERVICE } from '../../composables/organizations/useOrganizationType';
 
 const meta = {
-  title: "Components/Owners/Internals/Owner Type Icon",
+  title: "Components/Owners/Owner Type Icon",
   component: OwnerTypeIcon,
   tags: ['autodocs'],
   parameters: {

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerTypeIcon.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerTypeIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <Vicon v-if="icon" :name="icon"/>
+  <Vicon :scale="1/1.2" v-if="icon" :name="icon"/>
 </template>
 <script setup lang="ts">
 import { computed } from "vue";

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerTypeIcon.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerTypeIcon.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
   type: OrganizationTypes | UserType;
 }>();
 
-const wantedSize = 15;
+const wantedSize = 14;
 
 const icon = computed(() => {
   switch(props.type) {
@@ -35,3 +35,8 @@ const icon = computed(() => {
   }
 });
 </script>
+<style scoped>
+.ov-icon {
+  vertical-align: -0.1rem;
+}
+</style>

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerTypeIcon.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/Owner/OwnerTypeIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <Vicon :scale="1/1.2" v-if="icon" :name="icon"/>
+  <Vicon :height="wantedSize" :width="wantedSize" v-if="icon" :name="icon"/>
 </template>
 <script setup lang="ts">
 import { computed } from "vue";
@@ -13,6 +13,8 @@ addIcons(RiBankLine, RiBuilding2Line, RiCommunityLine, RiGovernmentLine, RiUserL
 const props = defineProps<{
   type: OrganizationTypes | UserType;
 }>();
+
+const wantedSize = 15;
 
 const icon = computed(() => {
   switch(props.type) {

--- a/udata_front/theme/gouvfr/datagouv-components/src/types/dataservices.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/types/dataservices.ts
@@ -13,7 +13,7 @@ export type Dataservice = Owned & {
   acronym: string;
   archived_at: string | null;
   authorization_request_url: string;
-  availability: number;
+  availability: number | null;
   base_api_url: string;
   contact_point: ContactPoint;
   created_at: string;


### PR DESCRIPTION
Closes https://github.com/datagouv/data.gouv.fr/issues/1435

For some reason, our new icon library apply a 1.2 outer scale factor to our organization icons.

This PR fixes it by adding an opposite scale.

It also fixes the dataservice card without availability

Note: [Previous PR](https://github.com/datagouv/udata-front/pull/472#pullrequestreview-2255078127) for context.