### PR TITLE
Add vue clamp to cards

### DIFF
--- a/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
+++ b/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
@@ -8,6 +8,7 @@
 - show permalink for community resources [#486](https://github.com/datagouv/udata-front/pull/486)
 - fix dataset card tooltip bug [#493](https://github.com/datagouv/udata-front/pull/493)
 - add url to reuse type [#494](https://github.com/datagouv/udata-front/pull/494)
+- add vue-clamp to cards title and description [#497](https://github.com/datagouv/udata-front/pull/497)
 
 ## 1.2.0 (2024-08-21)
 

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.stories.ts
@@ -55,7 +55,7 @@ const dataservice: Dataservice = {
     }
   ],
   deleted_at: null,
-  description: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.",
+  description: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.",
   endpoint_description_url: "",
   extras: {},
   format: "json",

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.stories.ts
@@ -99,7 +99,7 @@ const dataservice: Dataservice = {
   self_web_url: "",
   slug: "",
   tags: [],
-  title: "That Awesome API",
+  title: "That Awesome API That Awesome API That Awesome API That Awesome API That Awesome API ",
 };
 
 const args = {

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.vue
@@ -14,10 +14,10 @@
         {{ t('Archived') }}
       </p>
     </div>
-    <h4 class="fr-text--md fr-mb-0 fr-grid-row">
+    <h4 class="fr-text--md fr-mb-0">
       <slot name="dataserviceUrl" :dataservice="dataservice" :dataserviceUrl="dataserviceUrl">
         <span class="fr-icon-terminal-line fr-icon--sm fr-mr-1v" aria-hidden="true"></span>
-        <AppLink :to="dataserviceUrl">
+        <AppLink class="inline-flex" :to="dataserviceUrl">
           <TextClamp :auto-resize="true" :text='dataservice.title' :max-lines='1'/>
         </AppLink>
       </slot>

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.vue
@@ -18,7 +18,7 @@
       <slot name="dataserviceUrl" :dataservice="dataservice" :dataserviceUrl="dataserviceUrl">
         <span class="fr-icon-terminal-line fr-icon--sm fr-mr-1v" aria-hidden="true"></span>
         <AppLink :to="dataserviceUrl">
-          {{ dataservice.title }}
+          <TextClamp :auto-resize="true" :text='dataservice.title' :max-lines='1'/>
         </AppLink>
       </slot>
     </h4>
@@ -60,7 +60,6 @@ import type { RouteLocationRaw } from "vue-router";
 import TextClamp from 'vue3-text-clamp';
 import AppLink from "../AppLink/AppLink.vue";
 import type { Dataservice } from "../../types/dataservices";
-import { excerpt } from "../../helpers";
 import { formatRelativeIfRecentDate } from "../../helpers";
 import OrganizationNameWithCertificate from "../Organization/OrganizationNameWithCertificate.vue";
 import { useOwnerName } from "../../composables";

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.vue
@@ -44,7 +44,13 @@
         </template>
       </span>
     </p>
-    <p class="fr-text--sm fr-mt-1w fr-mb-0 overflow-wrap-anywhere" v-if="showDescription">{{ excerpt(dataservice.description, 160) }}</p>
+    <TextClamp
+      v-if="showDescription"
+      class="fr-text--sm fr-mt-1w fr-mb-0 overflow-wrap-anywhere"
+      :auto-resize="true"
+      :text="dataservice.description"
+      :max-lines='2'
+    />
   </article>
 </template>
 

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DatasetCard/DatasetCard.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DatasetCard/DatasetCard.stories.ts
@@ -67,7 +67,7 @@ const dataset: DatasetV2 = {
   title: "Données changement climatique - SQR",
   acronym: "DCC",
   archived: false,
-  description: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.",
+  description: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Eaque ipsa quae s iste natus error siab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.",
   tags: null,
   license: "lov2",
   frequency: "Unknown",

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DatasetCard/DatasetCard.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DatasetCard/DatasetCard.stories.ts
@@ -64,7 +64,7 @@ const dataset: DatasetV2 = {
     update_fulfilled_in_time: false,
   },
   metrics: { discussions: 12, followers: 25, reuses: 8, views: 59, resources_downloads:	18705 },
-  title: "Données changement climatique - SQR",
+  title: "Données changement climatique - Données changement climatique - Données changement climatique - Données changement climatique - SQR",
   acronym: "DCC",
   archived: false,
   description: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Eaque ipsa quae s iste natus error siab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.",

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DatasetCard/DatasetCard.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DatasetCard/DatasetCard.vue
@@ -69,9 +69,13 @@
             </p>
           </div>
         </div>
-        <div v-if="showDescription" class="fr-pt-2v">
-          <p class="fr-text--sm fr-m-0 overflow-wrap-anywhere">{{ excerpt(dataset.description, 160) }}</p>
-        </div>
+        <TextClamp
+          v-if="showDescription"
+          class="fr-text--sm fr-mt-1w fr-mb-0 overflow-wrap-anywhere"
+          :auto-resize="true"
+          :text="dataset.description"
+          :max-lines='2'
+        />
       </div>
     </div>
   </article>

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DatasetCard/DatasetCard.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DatasetCard/DatasetCard.vue
@@ -35,9 +35,9 @@
       <div class="fr-col-12 fr-col-sm">
         <h4 class="fr-text--md fr-mb-0 fr-grid-row">
           <slot name="datasetUrl" :dataset="dataset" :datasetUrl="datasetUrl">
-            <AppLink :to="datasetUrl" class="text-grey-500">
-              {{ dataset.title }}
-              <small v-if="dataset.acronym">{{ dataset.acronym }}</small>
+            <AppLink :to="datasetUrl" class="text-grey-500 fr-grid-row">
+              <TextClamp class="fr-col" :auto-resize="true" :text='dataset.title' :max-lines='1' />
+              <small class="fr-col-auto fr-ml-1w" v-if="dataset.acronym">{{ dataset.acronym }}</small>
             </AppLink>
           </slot>
         </h4>

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/ReuseCard/ReuseCard.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/ReuseCard/ReuseCard.stories.ts
@@ -58,7 +58,7 @@ const args: ReuseProps = {
       views: 36
     },
     organization: null,
-    title: "My new reuse",
+    title: "My new reuse reuse reuse with with with a a a very very very long long long name name name",
     image: "https://static.data.gouv.fr/images/aa/c1f583251a4697850bd01e2cc95877.png",
     image_thumbnail: "https://static.data.gouv.fr/images/aa/c1f583251a4697850bd01e2cc95877.png",
   },

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/ReuseCard/ReuseCard.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/ReuseCard/ReuseCard.vue
@@ -4,7 +4,7 @@
       <div class="fr-card__content fr-px-2w fr-py-1v">
         <h3 class="fr-card__title fr-text--md fr-mt-1v fr-mb-0">
           <AppLink class="text-grey-500" :to="reuseUrl">
-            {{ truncate(reuse.title, 55) }}
+            <TextClamp :auto-resize="true" :text='reuse.title' :max-lines='1' />
           </AppLink>
         </h3>
         <div class="fr-card__desc fr-mt-0 text-mention-grey">


### PR DESCRIPTION
Closes https://github.com/datagouv/data.gouv.fr/issues/1422
Removes the text length excerpt logic for our cards and use vue-clamp instead.

Vue-clamp is now used :
- for titles
- for organization names
- for descriptions (2 lines)