### PR TITLE
Display contact point contact form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add beta admin user's datasets page [#549](https://github.com/datagouv/udata-front/pull/549)
 - Add beta admin user's reuses page [#550](https://github.com/datagouv/udata-front/pull/550)
 - Add beta admin community resources page [#551](https://github.com/datagouv/udata-front/pull/551)
+- Display contact point contact form [#555](https://github.com/datagouv/udata-front/pull/555)
 
 ## 5.2.2 (2024-09-23)
 

--- a/udata_front/theme/gouvfr/templates/contact_point.html
+++ b/udata_front/theme/gouvfr/templates/contact_point.html
@@ -1,4 +1,4 @@
-{% if contact_point and (contact_point.name or contact_point.email) %}
+{% if contact_point and (contact_point.name or contact_point.email or contact_point.contact_form) %}
 <h2 class="subtitle fr-mt-3v fr-mb-1v">{{ _('Contact point') }}</h2>
 <p class="fr-text--sm fr-mt-0 fr-mb-3v">
     {% if contact_point.email %}
@@ -10,6 +10,14 @@
         >
             {{ contact_point.name or contact_point.email }}
         </a>
+    {% elif contact_point.contact_form %}
+            <a
+            href="{{ contact_point.contact_form }}"
+            rel="ugc nofollow noopener"
+            target="_blank"
+            class="fr-text--sm fr-link text-grey-500"
+        >
+            {{ contact_point.name or contact_point.contact_form }}
     {% else %}
         {{ contact_point.name }}
     {% endif %}


### PR DESCRIPTION
Follows https://github.com/datagouv/data.gouv.fr/issues/1509
Should be merged after https://github.com/opendatateam/udata/pull/3164

Currently prioritize email first if both infos are available.
We may want to display both information in the future.