### PR TITLE
Use created_at date in reuse card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add beta admin user's reuses page [#550](https://github.com/datagouv/udata-front/pull/550)
 - Add beta admin community resources page [#551](https://github.com/datagouv/udata-front/pull/551)
 - Display contact point contact form [#555](https://github.com/datagouv/udata-front/pull/555)
+- Use created_at date in reuse card [#556](https://github.com/datagouv/udata-front/pull/556)
 
 ## 5.2.2 (2024-09-23)
 

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/ReuseCard/ReuseCard.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/ReuseCard/ReuseCard.vue
@@ -16,7 +16,7 @@
               <OrganizationNameWithCertificate v-else :organization="reuse.organization" />
             </span>
             <TextClamp class="not-enlarged fr-mr-1v" :auto-resize="true" :text='ownerName' :max-lines='1' v-else />
-            <span class="dash-before-sm whitespace-nowrap">{{ t('published {date}', { date: formatRelativeIfRecentDate(reuse.last_modified) }) }}</span>
+            <span class="dash-before-sm whitespace-nowrap">{{ t('published {date}', { date: formatRelativeIfRecentDate(reuse.created_at) }) }}</span>
           </p>
           <div class="fr-grid-row fr-grid-row--middle">
             <p class="fr-text--sm fr-my-0 dash-after-sm">


### PR DESCRIPTION
We're having an inconsinstency between `published {date}` and `reuse.last_modified`.

The [figma](https://www.figma.com/design/fvtAhJSd1hURLxy8GXmc3k/%F0%9F%8E%81-%5BWIP%5D-Syt%C3%A8me-U?node-id=40-11929&node-type=canvas&t=RruWUxwAesoJm2VG-0) indeed mentions a `publié le` on reuse cards.
We are back to the situation before [this change](https://github.com/datagouv/udata-front/commit/94d27bd6b330c043633084e62a7d2b76ec972bb6#diff-f6833a222cba5b95277fae1ce7c0258feb369bc6d504bcc3d94e225bed050994R19).