### PR TITLE
Add back copy button without label

### DIFF
--- a/udata_front/theme/gouvfr/assets/less/content/typography.less
+++ b/udata_front/theme/gouvfr/assets/less/content/typography.less
@@ -29,7 +29,7 @@ h6,
 }
 
 .line-height-1 {
-    line-height: 1;
+    line-height: 1 !important;
 }
 
 .f-italic {

--- a/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
+++ b/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add missing `dataset` key to `CommunityResource` type [#551](https://github.com/datagouv/udata-front/pull/551)
 - Low enphasis on last element of charts [#562](https://github.com/datagouv/udata-front/pull/562)
 - Remove markdown from dataservice card [#568](https://github.com/datagouv/udata-front/pull/568)
+- Add back copy button without label  [#576](https://github.com/datagouv/udata-front/pull/576)
 
 ## 1.4.0 (2024-09-23)
 

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/CopyButton/CopyButton.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/CopyButton/CopyButton.stories.ts
@@ -45,3 +45,28 @@ export const Primary: StoryObj<typeof meta> = {
     text: "someTextToCopy"
   }
 };
+
+export const HideLabel: StoryObj<typeof meta> = {
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Copy text', async () => {
+      await userEvent.click(canvas.getByRole("button"));
+    });
+    const copiedContent = await navigator.clipboard.readText();
+    expect(args.text).toBe(copiedContent);
+  },
+  render: (args) => ({
+    components: { CopyButton },
+    setup() {
+      return { args };
+    },
+    template: '<CopyButton :label="args.label" :hide-label="args.hideLabel" :copied-label="args.copiedLabel" :text="args.text" />',
+  }),
+  args: {
+    label: "Copy",
+    copiedLabel: "Copied!",
+    text: "someTextToCopy",
+    hideLabel: true,
+  }
+};

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/CopyButton/CopyButton.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/CopyButton/CopyButton.vue
@@ -2,8 +2,8 @@
   <button
     type="button"
     @click="copy"
-    class="fr-text--sm fr-mb-0 whitespace-nowrap relative fr-p-1v text-mention-grey"
-    :class="{'border bg-white rounded-xxs line-height-1 text-grey-500': hideLabel }"
+    class="fr-text--sm fr-mb-0 whitespace-nowrap relative fr-p-1v text-mention-grey line-height-1"
+    :class="{'border bg-white rounded-xxs text-grey-500': hideLabel }"
   >
     <span v-if="copied" style="color: #3558a2;">
         <OhVueIcon :height="16" :width="16" name="ri-check-line" />

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/CopyButton/CopyButton.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/CopyButton/CopyButton.vue
@@ -1,27 +1,40 @@
 <template>
-  <button type="button" @click="copy" class="fr-text--xs fr-mb-0 whitespace-nowrap relative">
-      <span v-if="copied" style="color: #3558a2;">
-          <OhVueIcon name="ri-file-copy-line" class="fr-mr-1v" />
-          <span class="copy-label">{{ copiedLabel }}</span>  
-      </span>
-      <span v-if="!copied">
-          <OhVueIcon name="ri-file-copy-line" class="copy-icon fr-mr-1v" />
-          <span class="copy-link copy-label">{{ label }}</span>  
-      </span>
+  <button
+    type="button"
+    @click="copy"
+    class="fr-text--sm fr-mb-0 whitespace-nowrap relative fr-p-1v text-mention-grey"
+    :class="{'border bg-white rounded-xxs line-height-1 text-grey-500': hideLabel }"
+  >
+    <span v-if="copied" style="color: #3558a2;">
+        <OhVueIcon :height="16" :width="16" name="ri-check-line" />
+        <span class="fr-ml-1v copy-label" :class="{ 'fr-sr-only': hideLabel }">{{ copiedLabel }}</span>
+    </span>
+    <span v-if="!copied">
+        <OhVueIcon
+          :height="16"
+          :width="16"
+          :name="hideLabel ? 'ri-clipboard-line' : 'ri-file-copy-line'"
+          class="copy-icon"
+        />
+        <span class="fr-ml-1v copy-link copy-label" :class="{ 'fr-sr-only': hideLabel }">{{ label }}</span>
+    </span>
   </button>
 </template>
 <script setup lang="ts">
 import { ref } from 'vue';
-import { RiFileCopyLine } from "oh-vue-icons/icons";
+import { RiCheckLine, RiClipboardLine, RiFileCopyLine } from "oh-vue-icons/icons";
 import { OhVueIcon, addIcons } from 'oh-vue-icons';
 
-addIcons(RiFileCopyLine)
+addIcons(RiCheckLine, RiClipboardLine, RiFileCopyLine)
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   text: string;
   label: string;
   copiedLabel: string;
-}>();
+  hideLabel?: boolean;
+}>(), {
+  hideLabel: false,
+});
 
 const copied = ref(false);
 
@@ -38,14 +51,14 @@ button:hover .copy-icon {
 
 .copy-link {
   /* Using opacity here to prevent moving object with display:none (for example when clamping a text before the button) */
-  opacity: 0%; 
+  opacity: 0%;
 }
 button:hover .copy-link {
   opacity: 100%;
 }
 
 /*
-We may want to enable this to leave more space for title in small screens… But it also affects 
+We may want to enable this to leave more space for title in small screens… But it also affects
 buttons in the body of the resources panels and we don't want it…
 @container (max-width: 600px) {
   .copy-label {

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/InformationPanel/InformationPanel.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/InformationPanel/InformationPanel.vue
@@ -61,7 +61,7 @@
     <div class="fr-text--sm fr-m-0">
       <h3 class="subtitle fr-mb-1v">
         {{ $t('Integrate on your website') }}
-        <CopyButton :label="$t('Copy embed')" :copied-label="$t('Embed copied')" class="fr-my-1w fr-mr-1w" :text="embedText" />
+        <CopyButton :hide-label="true" :label="$t('Copy embed')" :copied-label="$t('Embed copied')" class="fr-my-1w fr-mr-1w" :text="embedText" />
       </h3>
       <div class="embed-wrapper">
         <textarea ref="textAreaRef" readonly="true" rows="1" v-model="embedText" @click="selectContent"></textarea>

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/ResourceAccordion/Metadata.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/ResourceAccordion/Metadata.vue
@@ -22,26 +22,26 @@ const { t } = useI18n();
     <div>
         <div class="flex gap-3rem flex-col-on-small">
             <DescriptionList class="flex-1">
-                <DescriptionTerm>{{ t('URL') }} <CopyButton :label="$t('Copy link')" :copied-label="$t('Link copied!')" :text="resource.url"/></DescriptionTerm>
+                <DescriptionTerm>{{ t('URL') }} <CopyButton :hide-label="true" :label="$t('Copy link')" :copied-label="$t('Link copied!')" :text="resource.url"/></DescriptionTerm>
                 <DescriptionDetails :with-ellipsis="false">
                     <code class="code">
                         <a :href="resource.url"><TextClamp :max-lines="1" :autoresize="true" :text="resource.url" /></a>
                     </code>
                 </DescriptionDetails>
-                <DescriptionTerm>{{ t('Stable URL') }} <CopyButton :label="$t('Copy link')" :copied-label="$t('Link copied!')" :text="resource.latest"/></DescriptionTerm>
+                <DescriptionTerm>{{ t('Stable URL') }} <CopyButton :hide-label="true" :label="$t('Copy link')" :copied-label="$t('Link copied!')" :text="resource.latest"/></DescriptionTerm>
                 <DescriptionDetails :with-ellipsis="false">
                     <code class="code">
                         <a :href="resource.latest"><TextClamp :max-lines="1" :autoresize="true" :text="resource.latest"/></a>
                     </code>
                 </DescriptionDetails>
-                <DescriptionTerm>{{ t('Identifier') }} <CopyButton :label="$t('Copy ID')" :copied-label="$t('ID copied!')" :text="resource.id"/></DescriptionTerm>
+                <DescriptionTerm>{{ t('Identifier') }} <CopyButton :hide-label="true" :label="$t('Copy ID')" :copied-label="$t('ID copied!')" :text="resource.id"/></DescriptionTerm>
                 <DescriptionDetails :with-ellipsis="false">
                     <code class="code">
                         <TextClamp :max-lines="1" :autoresize="true" :text="resource.id" />
                     </code>
                 </DescriptionDetails>
                 <template v-if="resource.checksum">
-                    <DescriptionTerm>{{resource.checksum.type}} <CopyButton :label="$t('Copy checksum')" :copied-label="$t('Checksum copied!')" :text="resource.checksum.value"/></DescriptionTerm>
+                    <DescriptionTerm>{{resource.checksum.type}} <CopyButton :hide-label="true" :label="$t('Copy checksum')" :copied-label="$t('Checksum copied!')" :text="resource.checksum.value"/></DescriptionTerm>
                     <DescriptionDetails :with-ellipsis="false">
                         <code class="code">
                             <TextClamp :max-lines="1" :autoresize="true" :text="resource.checksum.value" />


### PR DESCRIPTION
This one is required for copy button close to or inside input like the [new admin ones](https://www.figma.com/design/YbluH37N5lpcM0SgF65LdD/%E2%9A%99%EF%B8%8F-Administrations-et-modification-des-jeux-de-donn%C3%A9es?node-id=2265-44001&node-type=frame&t=r9W6O31X3TZhVShs-0).