### PR TITLE
Fix missing closing <a> tag in contact form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix missing closing <a> tag in contact form [#589](https://github.com/datagouv/udata-front/pull/589)
 
 ## 6.0.0 (2024-11-07)
 

--- a/udata_front/theme/gouvfr/templates/contact_point.html
+++ b/udata_front/theme/gouvfr/templates/contact_point.html
@@ -18,6 +18,7 @@
             class="fr-text--sm fr-link text-grey-500"
         >
             {{ contact_point.name or contact_point.contact_form }}
+        </a>
     {% else %}
         {{ contact_point.name }}
     {% endif %}


### PR DESCRIPTION
This currently breaks the layout as in https://www.data.gouv.fr/fr/dataservices/api-rappelconso/