### PR TITLE
fix: breadcrumb dataservices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix missing closing <a> tag in contact form [#589](https://github.com/datagouv/udata-front/pull/589)
+- Fix breadcrumb link for dataservice page [#590](https://github.com/datagouv/udata-front/pull/590)
 
 ## 6.0.0 (2024-11-07)
 

--- a/udata_front/theme/gouvfr/templates/dataservice/display.html
+++ b/udata_front/theme/gouvfr/templates/dataservice/display.html
@@ -23,8 +23,8 @@
 {% block breadcrumb %}
     {% cache cache_duration, 'dataservice-breadcrumb', dataservice.id|string, g.lang_code, dataservice.last_modified|string %}
         <li>
-            <a class="fr-breadcrumb__link">
-                {{ _('APIs') }}
+            <a class="fr-breadcrumb__link" href="{{ url_for('dataservices.list') }}">
+                {{ _('API') }}
             </a>
         </li>
         <li>

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -6,10 +6,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: udata-front 5.2.5.dev0\n"
+"Project-Id-Version: udata-front 6.0.1.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2024-11-07 10:51+0100\n"
-"PO-Revision-Date: 2024-11-07 10:51+0100\n"
+"POT-Creation-Date: 2024-11-08 10:39+0100\n"
+"PO-Revision-Date: 2024-11-08 10:39+0100\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -716,11 +716,8 @@ msgid "%(site)s administration panel"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataservice/display.html:11
-msgid "API"
-msgstr ""
-
 #: udata_front/theme/gouvfr/templates/dataservice/display.html:27
-msgid "APIs"
+msgid "API"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataservice/display.html:54


### PR DESCRIPTION
- Change wording `APIs` to `API` 
- Add link to dataservices page