### PR TITLE
Move datagouv/components deps to externals to avoid browser context

### DIFF
--- a/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
+++ b/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current (in progress)
 
+- Dependencies are now `externals` [#594](https://github.com/datagouv/udata-front/pull/594)
+
 ## 2.0.0 (2024-11-13)
 
 > [!WARNING]

--- a/udata_front/theme/gouvfr/datagouv-components/vite.config.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/vite.config.ts
@@ -31,18 +31,13 @@ export default defineConfig(config => {
         name: 'DataGouvFrComponents',
         // the proper extensions will be added
         fileName: 'data-gouv-fr-components',
+        formats: ['es']
       },
       rollupOptions: {
         // make sure to externalize deps that shouldn't be bundled
         // into your library
-        external: ['vue', 'vue-router'],
+        external: ['@headlessui/vue', 'axios', 'chart.js', 'remark', 'remark-gfm', 'strip-markdown', 'swagger-themes', 'swagger-ui', 'vue', 'vue-router'],
         output: {
-          // Provide global variables to use in the UMD build
-          // for externalized deps
-          globals: {
-            vue: 'Vue',
-            'vue-router': 'vueRouter'
-          },
           chunkFileNames: "chunks/[name]-[hash].js",
         },
       },


### PR DESCRIPTION
Our dependencies are currently inlined during the build process. This is causing errors in an SSR environment.

You can try it in `datagouv/front-end` with the following commands :

In datagouv-components :

```
npm i
npm run build
npm pack
```
This will make a file called `datagouv-components-2.0.0.tgz`

Then, in `datagouv/front-end` :
```
npm i PATH_TO/datagouv-components-2.0.0.tgz
```