### PR TITLE
Display correct business documentation url link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Display correct business documentation url link [#595](https://github.com/datagouv/udata-front/pull/595)
 
 ## 6.0.1 (2024-11-13)
 

--- a/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
+++ b/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Display correct business documentation url link [#595](https://github.com/datagouv/udata-front/pull/595)
 
 ## 2.0.1 (2024-11-13)
 

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceCard/DataserviceCard.stories.ts
@@ -57,6 +57,7 @@ const dataservice: Dataservice = {
   deleted_at: null,
   description: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.",
   endpoint_description_url: null,
+  business_documentation_url: null,
   extras: {},
   format: "json",
   harvest: {},

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceLinks/DataserviceLinks.stories.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceLinks/DataserviceLinks.stories.ts
@@ -37,6 +37,7 @@ const dataservice: Dataservice = {
   deleted_at: null,
   description: "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.",
   endpoint_description_url: "https://www.data.gouv.fr",
+  business_documentation_url: "https://guides.data.gouv.fr/api",
   extras: {},
   format: "json",
   harvest: {},
@@ -123,6 +124,7 @@ export const NoLinksDataserviceLinks: StoryObj<typeof meta> = {
     dataservice: {
       ...dataservice,
       endpoint_description_url: null,
+      business_documentation_url: null,
       base_api_url: null,
     }
   }

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceLinks/DataserviceLinks.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/DataserviceLinks/DataserviceLinks.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="border border-blue-400 fr-p-2w bg-alt-grey"
-      v-if="(!showSwaggerBox && dataservice.endpoint_description_url) || dataservice.business_documentation">
+      v-if="(!showSwaggerBox && dataservice.endpoint_description_url) || dataservice.business_documentation_url">
       <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
         <div class="fr-col-12 fr-col-sm">
           <h2 class="fr-h6 fr-mb-0 text-blue-400">{{ t("API documentation") }}</h2>
@@ -12,10 +12,10 @@
             {{ t('Technical Documentation') }}
           </a>
           <a
-            v-if="dataservice.business_documentation"
+            v-if="dataservice.business_documentation_url"
             class="fr-btn"
             :class="showSwaggerBox ? '' : 'fr-ml-3v fr-btn--secondary'"
-            :href="dataservice.business_documentation"
+            :href="dataservice.business_documentation_url"
             target="_blank"
             rel="ugc nofollow noopener"
           >

--- a/udata_front/theme/gouvfr/datagouv-components/src/types/dataservices.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/types/dataservices.ts
@@ -16,6 +16,7 @@ export type BaseDataservice = Owned & {
     }>;
   description: string;
   endpoint_description_url: string | null;
+  business_documentation_url: string | null;
   has_token: boolean;
   is_restricted: boolean;
   license: string | null;
@@ -46,6 +47,7 @@ export type Dataservice = Owned & {
   deleted_at: string | null;
   description: string;
   endpoint_description_url: string | null;
+  business_documentation_url: string | null;
   extras: Record<string, any>;
   format: string;
   harvest: Harvest;


### PR DESCRIPTION
Related to https://github.com/datagouv/data.gouv.fr/issues/1561.

`business_documentation_url` is being added in https://github.com/opendatateam/udata/pull/3193.