### PR TITLE
Rename wrongly named function

### DIFF
--- a/udata_front/theme/gouvfr/assets/js/components/AdminAddMember/AdminAddMemberModal.vue
+++ b/udata_front/theme/gouvfr/assets/js/components/AdminAddMember/AdminAddMemberModal.vue
@@ -85,7 +85,7 @@ export type AdminAddMemberModalProps = {
 </script>
 
 <script setup lang="ts">
-import type { User } from '@datagouv/components/ts';
+import { getUserAvatar, type User } from '@datagouv/components/ts';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { addMember } from "../../api/organizations";
@@ -93,7 +93,6 @@ import MultiSelect from "../MultiSelect/MultiSelect.vue";
 import SelectGroup, { type Option } from "../Form/SelectGroup/SelectGroup.vue";
 import type { MemberRole, MultiSelectOption } from '../../types';
 import { useToast } from '../../composables/useToast';
-import useUserAvatar from '../../composables/useUserAvatar';
 
 const props = defineProps<AdminAddMemberModalProps>();
 
@@ -131,7 +130,7 @@ function formatUsers(users: Array<UserSuggest>): Array<MultiSelectOption> {
     return  {
       value: user.id,
       label: user.first_name + " " + user.last_name,
-      image: useUserAvatar(user, 32),
+      image: getUserAvatar(user, 32),
     };
   });
 }

--- a/udata_front/theme/gouvfr/assets/js/components/ProducerSelector/ProducerSelector.vue
+++ b/udata_front/theme/gouvfr/assets/js/components/ProducerSelector/ProducerSelector.vue
@@ -50,11 +50,10 @@
 <script setup lang="ts">
 import { ref, computed, toValue, onMounted } from 'vue';
 import MultiSelect from '../../components/MultiSelect/MultiSelect.vue';
-import type { User, Organization, OwnedWithId } from '@datagouv/components/ts';
+import { getUserAvatar, type User, type Organization, type OwnedWithId } from '@datagouv/components/ts';
 import { organization_url } from '../../config';
 import type { Me } from '../../types';
 import { useI18n } from 'vue-i18n';
-import useUserAvatar from "../../composables/useUserAvatar";
 
 const { t } = useI18n();
 
@@ -96,8 +95,8 @@ function listOrganizations() {
     ...toValue(props.user),
     id: "user",
     name: `${props.user.first_name} ${props.user.last_name}`,
-    logo: useUserAvatar(toValue(props.user), 40),
-    logo_thumbnail: useUserAvatar(toValue(props.user), 40),
+    logo: getUserAvatar(toValue(props.user), 40),
+    logo_thumbnail: getUserAvatar(toValue(props.user), 40),
   };
   if (userValue) {
     organizations.value = [...userValue.organizations];

--- a/udata_front/theme/gouvfr/assets/js/composables/useUserAvatar.ts
+++ b/udata_front/theme/gouvfr/assets/js/composables/useUserAvatar.ts
@@ -1,7 +1,0 @@
-import { User } from "@datagouv/components/ts";
-import config from "../config";
-
-export default function useUserAvatar(user: User, size: number) {
-  const getIdenticon = (id: string, size: number) => `${config.api_root}avatars/${id}/${size}`;
-  return user.avatar_thumbnail || getIdenticon(user.id, size);
-}

--- a/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
+++ b/udata_front/theme/gouvfr/datagouv-components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Deprecate `useUserAvatar` and rename it to `getUserAvatar` to better convey its usage [#596](https://github.com/datagouv/udata-front/pull/596)
 
 ## 2.0.1 (2024-11-13)
 

--- a/udata_front/theme/gouvfr/datagouv-components/src/components/Avatar/Avatar.vue
+++ b/udata_front/theme/gouvfr/datagouv-components/src/components/Avatar/Avatar.vue
@@ -10,7 +10,8 @@
 </template>
 
 <script setup lang="ts">
-import useUserAvatar from "../../composables/useUserAvatar";
+import { computed } from "vue";
+import getUserAvatar from "../../helpers/getUserAvatar";
 import type { User } from "../../types/users";
 type Props = {
   rounded?: boolean;
@@ -21,5 +22,5 @@ const props = withDefaults(defineProps<Props>(), {
   rounded: false,
   size: 40,
 });
-const avatarUrl = useUserAvatar(props.user, props.size);
+const avatarUrl = computed(() => getUserAvatar(props.user, props.size));
 </script>

--- a/udata_front/theme/gouvfr/datagouv-components/src/composables/index.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/composables/index.ts
@@ -3,7 +3,6 @@ import useLicense from "./useLicense";
 import useOembed from "./useOEmbed";
 import useTabs from "./useTabs";
 import { useToast } from "./useToast";
-import useUserAvatar from "./useUserAvatar";
 import useOrganizationCertified, { CERTIFIED } from "./organizations/useOrganizationCertified";
 import useOrganizationType, { findOrganizationType, getOrganizationTypes, hasBadge, isType, ASSOCIATION, COMPANY, LOCAL_AUTHORITY, OTHER, PUBLIC_SERVICE, USER, type OrganizationTypes } from "./organizations/useOrganizationType";
 import useOwnerName from "./organizations/useOwnerName";
@@ -21,7 +20,6 @@ export {
   useOwnerName,
   useTabs,
   useToast,
-  useUserAvatar,
   ASSOCIATION,
   CERTIFIED,
   COMPANY,

--- a/udata_front/theme/gouvfr/datagouv-components/src/composables/useUserAvatar.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/composables/useUserAvatar.ts
@@ -1,7 +1,0 @@
-import { config } from "../config";
-import type { User } from "../types/users";
-
-export default function useUserAvatar(user: User, size: number) {
-  const getIdenticon = (id: string, size: number) => `${config.api_root}avatars/${id}/${size}`;
-  return user.avatar_thumbnail || getIdenticon(user.id, size);
-}

--- a/udata_front/theme/gouvfr/datagouv-components/src/helpers/getUserAvatar.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/helpers/getUserAvatar.ts
@@ -1,0 +1,14 @@
+import { config } from "../config";
+import type { User } from "../types/users";
+
+/**
+ * @deprecated use `getUserAvatar` instead, it isn't a composable so it shouldn't use the `use` convention
+ */
+export function useUserAvatar(user: User, size: number) {
+  return getUserAvatar(user, size);
+}
+
+export default function getUserAvatar(user: User, size: number) {
+  const getIdenticon = (id: string, size: number) => `${config.api_root}avatars/${id}/${size}`;
+  return user.avatar_thumbnail || getIdenticon(user.id, size);
+}

--- a/udata_front/theme/gouvfr/datagouv-components/src/helpers/index.ts
+++ b/udata_front/theme/gouvfr/datagouv-components/src/helpers/index.ts
@@ -1,9 +1,10 @@
+import { readonly } from "vue";
 import { useI18n } from "vue-i18n";
 import { dayjs } from "./i18n";
 import markdown, { removeMarkdown } from "./markdown";
 import { toggleAccordion } from "./toggleAccordion";
-import { readonly } from "vue";
 import { ResourceType } from "../types/resources";
+import getUserAvatar, { useUserAvatar } from "./getUserAvatar";
 
 export const RESOURCE_TYPE = readonly(["main", "documentation", "update", "api", "code", "other"] as const);
 
@@ -98,4 +99,4 @@ export const formatRelativeIfRecentDate = (date: Date | string) => {
   return formatFromNow(date);
 }
 
-export { markdown, removeMarkdown, toggleAccordion };
+export { getUserAvatar, markdown, removeMarkdown, toggleAccordion, useUserAvatar };


### PR DESCRIPTION
We have an helper function called like a composable, but it's not a composable.

Now this is fixed !