### PR TITLE
translation: rate limiting

### DIFF
--- a/udata_front/theme/gouvfr/translations/fr/LC_MESSAGES/gouvfr.po
+++ b/udata_front/theme/gouvfr/translations/fr/LC_MESSAGES/gouvfr.po
@@ -770,7 +770,7 @@ msgstr "Dernière mise à jour"
 
 #: udata_front/theme/gouvfr/templates/dataservice/display.html:110
 msgid "Rate limiting"
-msgstr "Limite"
+msgstr "Limite d'appels"
 
 #: udata_front/theme/gouvfr/templates/dataservice/display.html:115
 #: udata_front/theme/gouvfr/templates/dataservice/display.html:123


### PR DESCRIPTION
It was already ok in json files, just a missing .pot param