### PR TITLE
Remove duplicated /admin in admin dataservice route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Remove duplicated /admin in admin dataservice route [#608](https://github.com/datagouv/udata-front/pull/608)
 
 ## 6.0.2 (2024-11-19)
 

--- a/udata_front/views/beta.py
+++ b/udata_front/views/beta.py
@@ -12,7 +12,7 @@ class AdminView(LoginOnlyView):
 
 
 @blueprint.route(
-    '/admin/organizations/<organization_id>/dataservices/<dataservice_id>',
+    '/organizations/<organization_id>/dataservices/<dataservice_id>',
     endpoint='beta-admin-org-dataservice'
 )
 class AdminViewOrgDataservice(LoginOnlyView):
@@ -26,7 +26,7 @@ class AdminViewOrgDataservice(LoginOnlyView):
         return context
 
 
-@blueprint.route('/admin/me/dataservices/<dataservice_id>', endpoint='beta-admin-me-dataservice')
+@blueprint.route('/me/dataservices/<dataservice_id>', endpoint='beta-admin-me-dataservice')
 class AdminViewMeDataservice(LoginOnlyView):
     template_name = 'beta/admin.html'
 


### PR DESCRIPTION
The link behind `Modify` button on [a dataservice page](https://www.data.gouv.fr/fr/dataservices/api-fichier-des-comptes-bancaires-et-assimiles-ficoba/) has a duplicated `admin` in path