### PR TITLE
Disable session tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Disable sentry session tracking [#610](https://github.com/datagouv/udata-front/pull/610)
 
 ## 6.0.3 (2024-11-19)
 

--- a/udata_front/theme/gouvfr/assets/js/sentry.ts
+++ b/udata_front/theme/gouvfr/assets/js/sentry.ts
@@ -19,6 +19,7 @@ function InitSentry(app: App) {
         'ResizeObserver loop limit exceeded',
         'ResizeObserver loop completed with undelivered notifications.',
       ],
+      autoSessionTracking: false,
     })
     Sentry.setTags(sentry.tags)
   }


### PR DESCRIPTION
Sentry is sending so many session requests that we want to disable it for now.

It could be a problem with how many sentry instance we have on a given page, so maybe we can try to have [a single one with multiple vue apps](https://docs.sentry.io/platforms/javascript/guides/vue/features/multiple-apps/) later.