### PR TITLE
Use metadata_modifed_at in dataservice cache keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Disable sentry session tracking [#610](https://github.com/datagouv/udata-front/pull/610)
+- Use metadata_modifed_at in dataservice cache keys [#611](https://github.com/datagouv/udata-front/pull/611)
 
 ## 6.0.3 (2024-11-19)
 

--- a/udata_front/theme/gouvfr/templates/dataservice/display.html
+++ b/udata_front/theme/gouvfr/templates/dataservice/display.html
@@ -15,13 +15,13 @@
 {% set read_only_mode = config.READ_ONLY_MODE %}
 
 {% block extra_head %}
-    {% cache cache_duration, 'dataservice-extra-head', dataservice.id|string, g.lang_code, dataservice.last_modified|string %}
+    {% cache cache_duration, 'dataservice-extra-head', dataservice.id|string, g.lang_code, dataservice.metadata_modified_at|string %}
     <link rel="canonical" href="{{ url_for('dataservices.show', dataservice=dataservice) }}" />
     {% endcache %}
 {% endblock %}
 
 {% block breadcrumb %}
-    {% cache cache_duration, 'dataservice-breadcrumb', dataservice.id|string, g.lang_code, dataservice.last_modified|string %}
+    {% cache cache_duration, 'dataservice-breadcrumb', dataservice.id|string, g.lang_code, dataservice.metadata_modified_at|string %}
         <li>
             <a class="fr-breadcrumb__link" href="{{ url_for('dataservices.list') }}">
                 {{ _('API') }}


### PR DESCRIPTION
The main content was using the [correct cache key](https://github.com/datagouv/udata-front/blob/master/udata_front/theme/gouvfr/templates/dataservice/display.html#L63), but the breadcrumb and extras were based on last_modified that is not the wording on dataservice.

See also https://github.com/opendatateam/udata/pull/3207.