### PR TITLE
Update dataset params parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Disable sentry session tracking [#610](https://github.com/datagouv/udata-front/pull/610)
 - Use metadata_modifed_at in dataservice cache keys [#611](https://github.com/datagouv/udata-front/pull/611)
+- Update dataset params parsing to deal with tags correctly [#614](https://github.com/datagouv/udata-front/pull/614)
 
 ## 6.0.3 (2024-11-19)
 

--- a/udata_front/views/site.py
+++ b/udata_front/views/site.py
@@ -10,6 +10,7 @@ from udata.core.activity.models import Activity
 from udata.core.dataset.api import DatasetApiParser
 from udata.core.dataset.csv import ResourcesCsvAdapter
 from udata.core.dataset.models import Dataset
+from udata.core.dataset.search import DatasetSearch
 from udata.core.organization.api import OrgApiParser
 from udata.core.organization.csv import OrganizationCsvAdapter
 from udata.core.organization.models import Organization
@@ -111,11 +112,12 @@ def get_export_url(model):
 
 @blueprint.route('/datasets.csv')
 def datasets_csv():
-    params = multi_to_dict(request.args)
     # redirect to EXPORT_CSV dataset if feature is enabled and no filter is set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
-    if not params and 'dataset' in exported_models:
+    if not request.args and 'dataset' in exported_models:
         return redirect(get_export_url('dataset'))
+    search_parser = DatasetSearch.as_request_parser(store_missing=False)
+    params = search_parser.parse_args()
     params['facets'] = False
     datasets = DatasetApiParser.parse_filters(Dataset.objects.visible(), params)
     adapter = csv.get_adapter(Dataset)
@@ -124,11 +126,12 @@ def datasets_csv():
 
 @blueprint.route('/resources.csv')
 def resources_csv():
-    params = multi_to_dict(request.args)
     # redirect to EXPORT_CSV dataset if feature is enabled and no filter is set
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
-    if not params and 'resource' in exported_models:
+    if not request.args and 'resource' in exported_models:
         return redirect(get_export_url('resource'))
+    search_parser = DatasetSearch.as_request_parser(store_missing=False)
+    params = search_parser.parse_args()
     params['facets'] = False
     datasets = DatasetApiParser.parse_filters(Dataset.objects.visible(), params)
     return csv.stream(ResourcesCsvAdapter(datasets), 'resources')


### PR DESCRIPTION
Following https://github.com/opendatateam/udata/pull/3204, tags can now be a list and should be parsed using DatasetSearch parser.

This fixes the [CI error](https://app.circleci.com/jobs/github/datagouv/udata-front/35962) on `udata_front/tests/views/test_site.py::SiteViewsTest::test_datasets_csv_with_filters`

I did not find any other use of `multi_to_dict` related to datasets in udata-front

cc @abulte 