### PR TITLE
Add NATIONAL_MOURNING config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Add NATIONAL_MOURNING config [#625](https://github.com/datagouv/udata-front/pull/625)
 
 ## 6.0.6 (2024-12-09)
 

--- a/udata_front/settings.py
+++ b/udata_front/settings.py
@@ -78,3 +78,6 @@ SEARCH_SIREN_URL = None
 
 # Metadata quality is hidden for datasets harvested from these backends
 QUALITY_METADATA_BACKEND_IGNORE = []
+
+# Activate mourning style in case of national mourning
+NATIONAL_MOURNING = False

--- a/udata_front/theme/gouvfr/templates/raw.html
+++ b/udata_front/theme/gouvfr/templates/raw.html
@@ -2,7 +2,7 @@
 {%- set bundle = bundle|default('site') -%}
 {%- set bundle_js = '{0}.js'.format(bundle)-%}
 {%- set bundle_css = '{0}.css'.format(bundle)-%}
-<html lang="{{ g.lang_code }}" data-fr-scheme="light" data-fr-theme="light">
+<html lang="{{ g.lang_code }}" data-fr-scheme="light" data-fr-theme="light" {{ "data-fr-mourning" if config.NATIONAL_MOURNING else "" }}>
 
 <head>
     {% block raw_head %}


### PR DESCRIPTION
See [documentation](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/en-tete/) on data-fr-mourning