### PR TITLE
ci: trigger gitlab infra deployment through simple-scaffolding script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,7 +468,7 @@ jobs:
           command: |
             git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL scaffold
       - run:
-          name: Trigger Gitlab CI/CD pipeline for Hydra to deploy to dev environment
+          name: Trigger Gitlab CI/CD pipeline for udata+udata-front to deploy to dev environment
           command: |
             source set_env_builno.sh
             cd scaffold
@@ -479,7 +479,7 @@ jobs:
             # - udata: the name of the parent project to re-deploy (APP_NAME)
             # - $BUILDNO: the plugin build version to deploy (RELEASE_VERSION)
             # - << pipeline.parameters.deploy-env >>: the environment to deploy to (ENV)
-            # - "plugin_name=udata-front": the deploy variables (VARS). They are passed as a quoted string in which the variables are separated by commas.
+            # - "plugin_name=udata-front": the deploy variables (VARS). They are passed as a quoted string in which the variables are separated by semicolons.
             ./scripts/gitlab-ci-pipeline.sh udata ${BUILDNO} << pipeline.parameters.deploy-env >> "plugin_name=udata-front"
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ parameters:
   publish-branch:
     type: string
     default: "master"
-    description: "Branch to publish to PyPi and trigger the Gitlab CI/CD pipeline when pushed to"
+    description: "Branch to publish to PyPI and trigger the Gitlab CI/CD pipeline when pushed to"
   deploy-env:
     type: string
     default: "dev"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,7 +409,7 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Set version
+          name: Set release version
           command: |
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release, version has been handled upstream

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,13 +101,13 @@ jobs:
           command: |
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release
-                echo 'export BUILDNO="'$CIRCLE_TAG'"' >> version.sh
+                echo 'export BUILDNO="'$CIRCLE_TAG'"' > version.sh
             elif [[ "$CIRCLE_BRANCH" == feature/* ]]; then
                 # This is a feature branch
-                echo 'export BUILDNO="'$CIRCLE_BUILD_NUM+${CIRCLE_BRANCH#*/}'"' >> version.sh
+                echo 'export BUILDNO="'$CIRCLE_BUILD_NUM+${CIRCLE_BRANCH#*/}'"' > version.sh
             else
                 # This is a simple development build
-                echo 'export BUILDNO="'$CIRCLE_BUILD_NUM'"' >> version.sh
+                echo 'export BUILDNO="'$CIRCLE_BUILD_NUM'"' > version.sh
             fi
             source version.sh
             echo $BUILDNO
@@ -414,7 +414,7 @@ jobs:
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release, version has been handled upstream
                 RELEASE_VERSION=$CIRCLE_TAG
-                echo "RELEASE_VERSION=$RELEASE_VERSION" > version.sh
+                echo "RELEASE_VERSION=$RELEASE_VERSION" >> version.sh
             else
                 # Otherwise, relies on a dev version like "1.2.1.dev" by default
                 # Read base version from __init__.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,13 +109,13 @@ jobs:
           command: |
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release
-                echo 'export BUILDNO="'$CIRCLE_TAG'"' > version.sh
+                echo 'BUILDNO="'$CIRCLE_TAG'"' > version.sh
             elif [[ "$CIRCLE_BRANCH" == feature/* ]]; then
                 # This is a feature branch
-                echo 'export BUILDNO="'$CIRCLE_BUILD_NUM+${CIRCLE_BRANCH#*/}'"' > version.sh
+                echo 'BUILDNO="'$CIRCLE_BUILD_NUM+${CIRCLE_BRANCH#*/}'"' > version.sh
             else
                 # This is a simple development build
-                echo 'export BUILDNO="'$CIRCLE_BUILD_NUM'"' > version.sh
+                echo 'BUILDNO="'$CIRCLE_BUILD_NUM'"' > version.sh
             fi
             source version.sh
             echo $BUILDNO

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,15 +101,15 @@ jobs:
           command: |
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release
-                echo 'export BUILDNO="'$CIRCLE_TAG'"' >> set_env_builno.sh
+                echo 'export BUILDNO="'$CIRCLE_TAG'"' >> version.sh
             elif [[ "$CIRCLE_BRANCH" == feature/* ]]; then
                 # This is a feature branch
-                echo 'export BUILDNO="'$CIRCLE_BUILD_NUM+${CIRCLE_BRANCH#*/}'"' >> set_env_builno.sh
+                echo 'export BUILDNO="'$CIRCLE_BUILD_NUM+${CIRCLE_BRANCH#*/}'"' >> version.sh
             else
                 # This is a simple development build
-                echo 'export BUILDNO="'$CIRCLE_BUILD_NUM'"' >> set_env_builno.sh
+                echo 'export BUILDNO="'$CIRCLE_BUILD_NUM'"' >> version.sh
             fi
-            source set_env_builno.sh
+            source version.sh
             echo $BUILDNO
       - when:
           condition:
@@ -119,7 +119,7 @@ jobs:
                 name: Generate egg-info
                 command: |
                   source venv/bin/activate
-                  source set_env_builno.sh
+                  source version.sh
                   inv egg-info --buildno ${BUILDNO}
       - save_cache:
           key: py-cache-v16-{{ arch }}-{{ .Branch }}{{ .Environment.CIRCLE_TAG }}
@@ -140,7 +140,7 @@ jobs:
           paths:
           - venv
           - udata_front.egg-info
-          - set_env_builno.sh
+          - version.sh
 
   assets:
     docker:
@@ -321,7 +321,7 @@ jobs:
             - run:
                 name: Generate egg-info
                 command: |
-                  source set_env_builno.sh
+                  source version.sh
                   python setup.py egg_info --tag-build ${BUILDNO}
       - run:
           name: Prepare udata.cfg file with udata-front plugin
@@ -386,7 +386,7 @@ jobs:
             - run:
                 name: Generate egg-info
                 command: |
-                  source set_env_builno.sh
+                  source version.sh
                   python setup.py egg_info --tag-build ${BUILDNO}
 
       - run:
@@ -409,6 +409,29 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Set version
+          command: |
+            if [[ $CIRCLE_TAG ]]; then
+                # This is a tagged release, version has been handled upstream
+                RELEASE_VERSION=$CIRCLE_TAG
+                echo "RELEASE_VERSION=$RELEASE_VERSION" > version.sh
+            else
+                # Otherwise, relies on a dev version like "1.2.1.dev" by default
+                # Read base version from __init__.py
+                echo "BASE_VERSION=$(python -c "from udata import __version__; print(__version__)") >> version.sh
+                # Build the release version string with the build number, like "1.2.1.dev1234"
+                echo "RELEASE_VERSION=${BASE_VERSION}${BUILDNO}" >> version.sh
+            fi
+      - run:
+          name: Display build info for debugging
+          command: |
+            source version.sh
+            echo "Base version from __init__.py: $BASE_VERSION"
+            echo "Build number: $BUILDNO"
+            echo "Commit hash: ${CIRCLE_SHA1:0:7}"
+            echo "Git tag: $CIRCLE_TAG"
+            echo "Building a wheel release with version $RELEASE_VERSION"
+      - run:
           name: Build a distributable package
           command: |
             source venv/bin/activate
@@ -420,7 +443,7 @@ jobs:
                 inv pydist
             else
                 # This is a simple development build
-                source set_env_builno.sh
+                source version.sh
                 inv pydist -b ${BUILDNO}
             fi
       - store_artifacts:
@@ -470,7 +493,7 @@ jobs:
       - run:
           name: Trigger Gitlab CI/CD pipeline for udata+udata-front to deploy to dev environment
           command: |
-            source set_env_builno.sh
+            source version.sh
             cd scaffold
             # Run the script that triggers the Gitlab CI/CD pipeline.
             # Must have GITLAB_API_TOKEN set in the environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,12 +413,11 @@ jobs:
           command: |
             if [[ $CIRCLE_TAG ]]; then
                 # This is a tagged release, version has been handled upstream
-                RELEASE_VERSION=$CIRCLE_TAG
-                echo "RELEASE_VERSION=$RELEASE_VERSION" >> version.sh
+                echo "RELEASE_VERSION=$CIRCLE_TAG" >> version.sh
             else
                 # Otherwise, relies on a dev version like "1.2.1.dev" by default
                 # Read base version from __init__.py
-                echo "BASE_VERSION=$(python -c "from udata import __version__; print(__version__)") >> version.sh
+                echo "BASE_VERSION=$(python -c 'from udata import __version__; print(__version__)')" >> version.sh
                 # Build the release version string with the build number, like "1.2.1.dev1234"
                 echo "RELEASE_VERSION=${BASE_VERSION}${BUILDNO}" >> version.sh
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,14 @@ parameters:
     type: string
     default: "dev"
     description: "Environment to deploy to"
+  app-name:
+    type: string
+    default: "udata"
+    description: "Parent app name"
+  plugin-name:
+    type: string
+    default: "udata-front"
+    description: "Plugin name"
 
 orbs:
   browser-tools: circleci/browser-tools@1.2.3
@@ -417,7 +425,7 @@ jobs:
             else
                 # Otherwise, relies on a dev version like "1.2.1.dev" by default
                 # Read base version from __init__.py
-                echo "BASE_VERSION=$(python -c 'from udata import __version__; print(__version__)')" >> version.sh
+                echo "BASE_VERSION=$(python -c 'from << pipeline.parameters.plugin-name >> import __version__; print(__version__)')" >> version.sh
                 # Build the release version string with the build number, like "1.2.1.dev1234"
                 echo "RELEASE_VERSION=${BASE_VERSION}${BUILDNO}" >> version.sh
             fi
@@ -490,7 +498,7 @@ jobs:
           command: |
             git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL scaffold
       - run:
-          name: Trigger Gitlab CI/CD pipeline for udata+udata-front to deploy to dev environment
+          name: Trigger Gitlab CI/CD pipeline for << pipeline.parameters.app-name >> +<< pipeline.parameters.plugin-name >> to deploy to << pipeline.parameters.deploy-env >> environment
           command: |
             source version.sh
             cd scaffold
@@ -498,11 +506,11 @@ jobs:
             # Must have GITLAB_API_TOKEN set in the environment
             # GITLAB_API_TOKEN is the token related to the "infra" GitLab repository, so that the Gitlab CI/CD pipeline can be triggered
             # The script args are, in order:
-            # - udata: the name of the parent project to re-deploy (APP_NAME)
+            # - << pipeline.parameters.app-name >>: the name of the parent project to re-deploy (APP_NAME)
             # - $BUILDNO: the plugin build version to deploy (RELEASE_VERSION)
             # - << pipeline.parameters.deploy-env >>: the environment to deploy to (ENV)
-            # - "plugin_name=udata-front": the deploy variables (VARS). They are passed as a quoted string in which the variables are separated by semicolons.
-            ./scripts/gitlab-ci-pipeline.sh udata ${BUILDNO} << pipeline.parameters.deploy-env >> "plugin_name=udata-front"
+            # - "plugin_name=<< pipeline.parameters.plugin-name >>": the deploy variables (VARS). They are passed as a quoted string in which the variables are separated by semicolons.
+            ./scripts/gitlab-ci-pipeline.sh << pipeline.parameters.app-name >> ${BUILDNO} << pipeline.parameters.deploy-env >> "plugin_name=<< pipeline.parameters.plugin-name >>"
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,7 @@ jobs:
                 # Otherwise, relies on a dev version like "1.2.1.dev" by default
                 # Read base version from __init__.py
                 source venv/bin/activate
-                echo "BASE_VERSION=$(python -c 'from << pipeline.parameters.plugin-name >> import __version__; print(__version__)')" >> version.sh
+                echo "BASE_VERSION=$(python -c 'from udata_front import __version__; print(__version__)')" >> version.sh
                 # Build the release version string with the build number, like "1.2.1.dev1234"
                 echo "RELEASE_VERSION=${BASE_VERSION}${BUILDNO}" >> version.sh
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,6 +425,7 @@ jobs:
             else
                 # Otherwise, relies on a dev version like "1.2.1.dev" by default
                 # Read base version from __init__.py
+                source venv/bin/activate
                 echo "BASE_VERSION=$(python -c 'from << pipeline.parameters.plugin-name >> import __version__; print(__version__)')" >> version.sh
                 # Build the release version string with the build number, like "1.2.1.dev1234"
                 echo "RELEASE_VERSION=${BASE_VERSION}${BUILDNO}" >> version.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,16 @@
 ---
 version: 2.1
 
+parameters:
+  publish-branch:
+    type: string
+    default: "master"
+    description: "Branch to publish to PyPi and trigger the Gitlab CI/CD pipeline when pushed to"
+  deploy-env:
+    type: string
+    default: "dev"
+    description: "Environment to deploy to"
+
 orbs:
   browser-tools: circleci/browser-tools@1.2.3
   cypress: cypress-io/cypress@3
@@ -71,7 +81,7 @@ jobs:
       - image: mongo:6.0.4
       - image: redis:alpine
     environment:
-       BASH_ENV: /root/.bashrc
+        BASH_ENV: /root/.bashrc
     steps:
       - checkout
       - attach_workspace:
@@ -393,7 +403,7 @@ jobs:
     docker:
       - image: udata/circleci:py3.11-bookworm
     environment:
-       BASH_ENV: /root/.bashrc
+        BASH_ENV: /root/.bashrc
     steps:
       - checkout
       - attach_workspace:
@@ -433,8 +443,46 @@ jobs:
             pip install twine
             twine upload --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" dist/*.whl
 
+  trigger-gitlab-pipeline:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Configure the SSH simple-scaffold repository private key
+          command: |
+            mkdir -p ~/.ssh
+            # SCAFFOLD_PRIVATE_KEY is the private key related to the "simple-scaffold" GitLab repository, so that it can be cloned
+            # CircleCI doesn't accept multiple lines in a single environment variable, so the multiline private key must be base64 encoded, and then decoded here
+            echo "$SCAFFOLD_PRIVATE_KEY" | base64 -d > ~/.ssh/id_ed25519
+            chmod 600 ~/.ssh/id_ed25519
+            ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
+      - run:
+          name: Configure Git
+          command: |
+            git config --global user.email "root@data.gouv.fr"
+            git config --global user.name "datagouv"
+      - run:
+          name: Clone simple-scaffold repository
+          command: |
+            git clone --quiet --depth 1 $SCAFFOLD_REPO_SSH_URL scaffold
+      - run:
+          name: Trigger Gitlab CI/CD pipeline for Hydra to deploy to dev environment
+          command: |
+            source set_env_builno.sh
+            cd scaffold
+            # Run the script that triggers the Gitlab CI/CD pipeline.
+            # Must have GITLAB_API_TOKEN set in the environment
+            # GITLAB_API_TOKEN is the token related to the "infra" GitLab repository, so that the Gitlab CI/CD pipeline can be triggered
+            # The script args are, in order:
+            # - udata: the name of the parent project to re-deploy (APP_NAME)
+            # - $BUILDNO: the plugin build version to deploy (RELEASE_VERSION)
+            # - << pipeline.parameters.deploy-env >>: the environment to deploy to (ENV)
+            # - "plugin_name=udata-front": the deploy variables (VARS). They are passed as a quoted string in which the variables are separated by commas.
+            ./scripts/gitlab-ci-pipeline.sh udata ${BUILDNO} << pipeline.parameters.deploy-env >> "plugin_name=udata-front"
+
 workflows:
-  version: 2
   build:
     jobs:
       - deps:
@@ -508,7 +556,17 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - << pipeline.parameters.publish-branch >>
             tags:
               only: /v[0-9]+(\.[0-9]+)*(\.(a|b|rc)[0-9]*)*/
           context: org-global
+      - trigger-gitlab-pipeline:
+          requires:
+            - publish
+          filters:
+            branches:
+              only:
+                - << pipeline.parameters.publish-branch >>
+          context:
+            - org-global
+            - gitlab-trigger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,12 +427,13 @@ jobs:
                 # Read base version from __init__.py
                 source venv/bin/activate
                 echo "BASE_VERSION=$(python -c 'from udata_front import __version__; print(__version__)')" >> version.sh
-                # Build the release version string with the build number, like "1.2.1.dev1234"
-                echo "RELEASE_VERSION=${BASE_VERSION}${BUILDNO}" >> version.sh
+                # Build the release version string with the concatenated version and build number, like "1.2.1.dev1234"
+                echo "RELEASE_VERSION=\"\${BASE_VERSION}\${BUILDNO}\"" >> version.sh
             fi
       - run:
           name: Display build info for debugging
           command: |
+            cat version.sh
             source version.sh
             echo "Base version from __init__.py: $BASE_VERSION"
             echo "Build number: $BUILDNO"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix following cache issue [#631](https://github.com/datagouv/udata-front/pull/631)
 - Add dataservice search to header [#622](https://github.com/datagouv/udata-front/pull/622)
+- Trigger GitLab infra deployment through simple-scaffolding script [#632](https://github.com/datagouv/udata-front/pull/632)
 
 ## 6.0.7 (2024-12-20)
 


### PR DESCRIPTION
Similar to https://github.com/datagouv/hydra/pull/186 on Hydra, this PR adds automatic deployment by triggering GitLab infra CI through the simple-scaffolding script.

- Add `trigger-gitlab-pipeline` job using `simple-scaffolding` deploy script and the existing `$BUILDNO` var
- Add CI parameters `publish-branch` and `deploy-env`

This CI needs:

SCAFFOLD_PRIVATE_KEY to be created and added
[x] private one to be added as CircleCI env
[x] public one to be added on simple-scaffold GitLab repo
GITLAB_API_TOKEN to be created and added
[x] on GitLab infra API tokens
[x] on CircleCI env