### PR TITLE
Fix minor home typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Fix homepage translations [#644](https://github.com/datagouv/udata-front/pull/644)
+- Fix homepage translations and links [#644](https://github.com/datagouv/udata-front/pull/644) [#648](https://github.com/datagouv/udata-front/pull/648)
 
 ## 6.1.0 (2025-01-20)
 

--- a/udata_front/theme/gouvfr/__init__.py
+++ b/udata_front/theme/gouvfr/__init__.py
@@ -47,29 +47,35 @@ gouvfr_menu = nav.Bar('gouvfr_menu', [
     nav.Item(_('API'), 'dataservices.list'),
     nav.Item(_('Reuses'), 'reuses.list'),
     nav.Item(_('Organizations'), 'organizations.list'),
-    nav.Item(_('Getting started on {site}'
-               .format(site=current_app.config.get('SITE_TITLE'))), None, items=[
-        nav.Item(
-            _('What is {site}?'.format(site=current_app.config.get('SITE_TITLE'))),
-            'gouvfr.show_page',
-            args={'slug': 'about/a-propos_data-gouv'}
+    nav.Item(_('Getting started on {site}').format(
+            site=current_app.config.get('SITE_TITLE')
         ),
-        nav.Item(
-            _('How to publish data ?'),
-            'gouvfr.show_page',
-            args={'slug': 'onboarding/producteurs'}
-        ),
-        nav.Item(
-            _('How to use data ?'),
-            'gouvfr.show_page',
-            args={'slug': 'onboarding/reutilisateurs'}
-        ),
-        nav.Item(
-            _('data.gouv.fr guides'),
-            None,
-            url=current_app.config.get('GUIDES_URL')
-        ),
-    ]),
+        None,
+        items=[
+            nav.Item(
+                _('What is {site}?').format(
+                    site=current_app.config.get('SITE_TITLE')
+                ),
+                'gouvfr.show_page',
+                args={'slug': 'about/a-propos_data-gouv'}
+            ),
+            nav.Item(
+                _('How to publish data ?'),
+                'gouvfr.show_page',
+                args={'slug': 'onboarding/producteurs'}
+            ),
+            nav.Item(
+                _('How to use data ?'),
+                'gouvfr.show_page',
+                args={'slug': 'onboarding/reutilisateurs'}
+            ),
+            nav.Item(
+                _('data.gouv.fr guides'),
+                None,
+                url=current_app.config.get('GUIDES_URL')
+            ),
+        ]
+    ),
     nav.Item(_('News'), 'posts.list'),
     nav.Item(_('Contact us'), None, url=current_app.config.get('SUPPORT_URL', '#')),
 ])

--- a/udata_front/theme/gouvfr/templates/home.html
+++ b/udata_front/theme/gouvfr/templates/home.html
@@ -315,7 +315,7 @@
                                 <p class="fr-card__desc text-grey-500 fr-text--lg fr-text--bold fr-mb-0 fr-mt-1w">{{_('Check public legal details of company, association and public services in France.')}}</p>
                             </div>
                             <div class="fr-card__footer fr-grid-row fr-grid-row--right">
-                                <a class="fr-link" href="https://https://annuaire-entreprises.data.gouv.fr/">
+                                <a class="fr-link" href="https://annuaire-entreprises.data.gouv.fr/">
                                     {{_('Learn more')}}
                                     <span class="fr-icon-arrow-right-line fr-icon--sm fr-ml-1v" aria-hidden="true"></span>
                                 </a>


### PR DESCRIPTION
* [Fix href to annuaire-entreprises](https://github.com/datagouv/udata-front/commit/67066fe08131920200f89ed2762da9bb63e9d992)
* [Fix translation in home (due to format inside gettext)](https://github.com/datagouv/udata-front/commit/97f049b01ad9dfe2c9bf02e5418fa6b6653358ac)