### PR TITLE
Fix security tests after udata changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Fix homepage translations and links [#644](https://github.com/datagouv/udata-front/pull/644) [#648](https://github.com/datagouv/udata-front/pull/648)
+- Fix security tests after udata changes [#650](https://github.com/datagouv/udata-front/pull/650)
 
 ## 6.1.0 (2025-01-20)
 

--- a/udata_front/tests/views/test_security.py
+++ b/udata_front/tests/views/test_security.py
@@ -12,7 +12,7 @@ class SecurityViewsTest(GouvfrFrontTestCase):
         '''Login should redirect to the correct next endpoint: homepage'''
         response = self.get(url_for('site.home'))
         lang = self.app.config['DEFAULT_LANGUAGE']
-        expected = f'href="/{lang}/login?next=%2F{lang}%2F"'
+        expected = f'href="/{lang}/login/?next=%2F{lang}%2F"'
         assert expected.encode('utf-8') in response.data
 
     def test_security_login_next_datasets(self):
@@ -20,12 +20,12 @@ class SecurityViewsTest(GouvfrFrontTestCase):
         dataset = DatasetFactory(slug="dataset-slug")
         response = self.get(url_for('datasets.show', dataset=dataset))
         lang = self.app.config['DEFAULT_LANGUAGE']
-        expected = f'href="/{lang}/login?next=%2F{lang}%2Fdatasets%2Fdataset-slug%2F"'
+        expected = f'href="/{lang}/login/?next=%2F{lang}%2Fdatasets%2Fdataset-slug%2F"'
         assert expected.encode('utf-8') in response.data
 
     def test_security_login_next_exception_site_home(self):
         '''Login should redirect to the homepage if current request has an exception'''
         response = self.get(url_for('datasets.show', dataset='dataset-not-found'))
         lang = self.app.config['DEFAULT_LANGUAGE']
-        expected = f'href="/{lang}/login?next=%2F{lang}%2F"'
+        expected = f'href="/{lang}/login/?next=%2F{lang}%2F"'
         assert expected.encode('utf-8') in response.data


### PR DESCRIPTION
Udata adds trailing slashes to security URLs but we are checking the old ones here