### PR TITLE
Fix dataservices edit button routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Support null end date for temporal coverage [#411](https://github.com/datagouv/udata-front/pull/411)
+- Fix dataservices edit button routing [#664](https://github.com/datagouv/udata-front/pull/664)
 
 ## 6.1.2 (2025-02-20)
 

--- a/udata_front/theme/gouvfr/templates/dataservice/display.html
+++ b/udata_front/theme/gouvfr/templates/dataservice/display.html
@@ -40,17 +40,10 @@
 {{ report_btn(dataservice) }}
 {% if can_edit %}
 <div class="fr-col-auto fr-ml-3v">
-    {% if dataservice.organization %}
+    {% if config.NEW_ADMIN_URL %}
     <a
         class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-warning-425 fr-icon-pencil-line fr-btn--icon-left"
-        href="{{ url_for('beta.beta-admin-org-dataservice', organization_id=dataservice.organization.id, dataservice_id=dataservice.id) }}"
-    >
-        {{ _('Edit') }}
-    </a>
-    {% else %}
-    <a
-        class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-warning-425 fr-icon-pencil-line fr-btn--icon-left"
-        href="{{ url_for('beta.beta-admin-me-dataservice', dataservice_id=dataservice.id) }}"
+        href="{{ beta_admin_url_for(path='dataservices/{id}/'.format(id=dataservice.id), fallback_path='dataservice/{id}/'.format(id=dataservice.id)) }}"
     >
         {{ _('Edit') }}
     </a>


### PR DESCRIPTION
 Actual edit button routes to `/admin/organizations/<org_id>/dataservices/<dataservice_id>` instead of `/admin/dataservices/<dataservice_id>`.

Stop relying on udata-front dataservices views routing but use beta_admin_url_for routing.