### PR TITLE
Optimize dataset detail view for dataset with many resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Optimize dataset detail view for dataset with many resources [#673](https://github.com/datagouv/udata-front/pull/673)
+- Update dataservice type and remove unused stuff [#655](https://github.com/datagouv/udata-front/pull/655)
 
 ## 6.1.4 (2025-03-10)
 

--- a/udata_front/views/dataset.py
+++ b/udata_front/views/dataset.py
@@ -90,10 +90,10 @@ class DatasetDetailView(DatasetView, DetailView):
         context = super(DatasetDetailView, self).get_context()
 
         params_dataservices_page = request.args.get("dataservices_page", 1, type=int)
-        dataservices = Dataservice.objects(datasets=self.dataset).visible()
+        dataservices = Dataservice.objects(datasets=self.dataset.id).visible()
 
         params_reuses_page = request.args.get('reuses_page', 1, type=int)
-        reuses = Reuse.objects(datasets=self.dataset).visible()
+        reuses = Reuse.objects(datasets=self.dataset.id).visible()
 
         if not DatasetEditPermission(self.dataset).can():
             if self.dataset.private:


### PR DESCRIPTION
Iterates on https://github.com/datagouv/data.gouv.fr/issues/1669

Using `dataset` object instead of his id only in `objects().paginate` seems to make a huge difference.
In my setup, I go from ~6,5 to ~4 sec for http://dev.local:7000/fr/datasets/643671587b87c77bffaae082/.

```
In [1]: from udata.models import Dataset, Organization, Resource, Discussion, Reuse, Site, User, Transfer, Post, Activity

In [2]: dataset = Dataset.objects(id="643671587b87c77bffaae082").first()

In [3]: %timeit Reuse.objects(datasets=dataset).visible().paginate(1,8)
2.93 s ± 16.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: %timeit Reuse.objects(datasets=dataset.id).visible().paginate(1,8)
12.8 ms ± 78.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

