### PR TITLE
Use python parenthesis format for translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Fix menu translation using python parenthesis format [#678](https://github.com/datagouv/udata-front/pull/678)
 
 ## 6.1.5 (2025-03-14)
 

--- a/udata_front/theme/gouvfr/__init__.py
+++ b/udata_front/theme/gouvfr/__init__.py
@@ -47,15 +47,11 @@ gouvfr_menu = nav.Bar('gouvfr_menu', [
     nav.Item(_('API'), 'dataservices.list'),
     nav.Item(_('Reuses'), 'reuses.list'),
     nav.Item(_('Organizations'), 'organizations.list'),
-    nav.Item(_('Getting started on {site}').format(
-            site=current_app.config.get('SITE_TITLE')
-        ),
+    nav.Item(_('Getting started on %(site)s', site=current_app.config.get('SITE_TITLE')),
         None,
         items=[
             nav.Item(
-                _('What is {site}?').format(
-                    site=current_app.config.get('SITE_TITLE')
-                ),
+                _('What is %(site)s?', site=current_app.config.get('SITE_TITLE')),
                 'gouvfr.show_page',
                 args={'slug': 'about/a-propos_data-gouv'}
             ),

--- a/udata_front/theme/gouvfr/__init__.py
+++ b/udata_front/theme/gouvfr/__init__.py
@@ -47,7 +47,10 @@ gouvfr_menu = nav.Bar('gouvfr_menu', [
     nav.Item(_('API'), 'dataservices.list'),
     nav.Item(_('Reuses'), 'reuses.list'),
     nav.Item(_('Organizations'), 'organizations.list'),
-    nav.Item(_('Getting started on %(site)s', site=current_app.config.get('SITE_TITLE')),
+    nav.Item(_(
+            'Getting started on %(site)s',
+            site=current_app.config.get('SITE_TITLE')
+        ),
         None,
         items=[
             nav.Item(

--- a/udata_front/theme/gouvfr/translations/gouvfr.pot
+++ b/udata_front/theme/gouvfr/translations/gouvfr.pot
@@ -6,10 +6,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: udata-front 6.1.5.dev0\n"
+"Project-Id-Version: udata-front 6.1.6.dev0\n"
 "Report-Msgid-Bugs-To: data.gouv@data.gouv.fr\n"
-"POT-Creation-Date: 2025-03-14 10:19+0100\n"
-"PO-Revision-Date: 2025-03-14 10:19+0100\n"
+"POT-Creation-Date: 2025-03-21 11:13+0100\n"
+"PO-Revision-Date: 2025-03-21 11:13+0100\n"
 "Last-Translator: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
 "Language: en\n"
 "Language-Team: Data.gouv.fr Team <data.gouv@data.gouv.fr>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.12.1\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: udata_front/forms.py:13
 msgid "First name"
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Invalid Captcha"
 msgstr ""
 
-#: udata_front/models.py:16 udata_front/theme/gouvfr/__init__.py:87
+#: udata_front/models.py:16 udata_front/theme/gouvfr/__init__.py:83
 msgid "Reference Data"
 msgstr ""
 
@@ -144,95 +144,97 @@ msgid "Organizations"
 msgstr ""
 
 #: udata_front/theme/gouvfr/__init__.py:50
-msgid "Getting started on {site}"
+#, python-format
+msgid "Getting started on %(site)s"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:56
-msgid "What is {site}?"
+#: udata_front/theme/gouvfr/__init__.py:54
+#, python-format
+msgid "What is %(site)s?"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:63
+#: udata_front/theme/gouvfr/__init__.py:59
 msgid "How to publish data ?"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:68
+#: udata_front/theme/gouvfr/__init__.py:64
 msgid "How to use data ?"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:73
+#: udata_front/theme/gouvfr/__init__.py:69
 msgid "data.gouv.fr guides"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:79
+#: udata_front/theme/gouvfr/__init__.py:75
 #: udata_front/theme/gouvfr/templates/home.html:25
 #: udata_front/theme/gouvfr/templates/post/display.html:19
 msgid "News"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:80 udata_front/theme/gouvfr/__init__.py:111
+#: udata_front/theme/gouvfr/__init__.py:76 udata_front/theme/gouvfr/__init__.py:107
 msgid "Contact us"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:86
+#: udata_front/theme/gouvfr/__init__.py:82
 #: udata_front/theme/gouvfr/templates/topic/datasets.html:15
 #: udata_front/theme/gouvfr/templates/topic/display.html:16
 #: udata_front/theme/gouvfr/templates/topic/reuses.html:15
 msgid "Topics"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:99
+#: udata_front/theme/gouvfr/__init__.py:95
 msgid "Data catalog"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:100
+#: udata_front/theme/gouvfr/__init__.py:96
 msgid "Follow data opening"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:102
+#: udata_front/theme/gouvfr/__init__.py:98
 msgid "Portal for European data"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:109
+#: udata_front/theme/gouvfr/__init__.py:105
 msgid "Guides"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:110
+#: udata_front/theme/gouvfr/__init__.py:106
 msgid "Roadmap and news"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:112
+#: udata_front/theme/gouvfr/__init__.py:108
 msgid "Give us your feedback"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:114
+#: udata_front/theme/gouvfr/__init__.py:110
 msgid "Statistics"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:120
+#: udata_front/theme/gouvfr/__init__.py:116
 msgid "api.gouv.fr"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:121
+#: udata_front/theme/gouvfr/__init__.py:117
 msgid "schema.data.gouv.fr"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:131
+#: udata_front/theme/gouvfr/__init__.py:127
 msgid "Licenses"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:132
+#: udata_front/theme/gouvfr/__init__.py:128
 msgid "Terms of use"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:133
+#: udata_front/theme/gouvfr/__init__.py:129
 msgid "Tracking and privacy"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:134
+#: udata_front/theme/gouvfr/__init__.py:130
 msgid "Legal notice"
 msgstr ""
 
-#: udata_front/theme/gouvfr/__init__.py:135
+#: udata_front/theme/gouvfr/__init__.py:131
 msgid "Accessibility: partially compliant"
 msgstr ""
 
@@ -329,6 +331,7 @@ msgid "Portal's API"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/footer.html:54
+#, python-brace-format
 msgid "Open-source engine: udata ({version})"
 msgstr ""
 
@@ -337,6 +340,7 @@ msgid "data.gouv.fr extension: udata-front"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/footer.html:65
+#, python-brace-format
 msgid "udata theme extension: udata-front ({version})"
 msgstr ""
 
@@ -353,6 +357,7 @@ msgid "Select a Language"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/footer.html:144
+#, python-brace-format
 msgid ""
 "Unless otherwise stated, all content of this site is availabe under <a "
 "href='{lo_url}'>Open Licence 2.0</a>"
@@ -438,6 +443,7 @@ msgid "Publish on "
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/header.html:266
+#, python-brace-format
 msgid ""
 "This is a degraded experience of {site}. Please enable JavaScript and use an "
 "up to date browser."
@@ -489,6 +495,7 @@ msgid "Discover data on all subjects, made by the administration and civil socie
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/home.html:79
+#, python-brace-format
 msgid "They publish data on {site}"
 msgstr ""
 
@@ -515,6 +522,7 @@ msgid "Share your data usage and exchange between data producers and reusers."
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/home.html:175
+#, python-brace-format
 msgid "They reuse data from {site}"
 msgstr ""
 
@@ -533,6 +541,7 @@ msgid "reuses"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/home.html:252
+#, python-brace-format
 msgid "{site} mission"
 msgstr ""
 
@@ -547,6 +556,7 @@ msgid ""
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/home.html:256
+#, python-brace-format
 msgid ""
 "{site} makes this information available by organizing its distribution and "
 "use."
@@ -569,6 +579,7 @@ msgid "Encourage data reusability"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/home.html:273
+#, python-brace-format
 msgid "Learn more about {site}"
 msgstr ""
 
@@ -634,6 +645,7 @@ msgid ""
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/home.html:394
+#, python-brace-format
 msgid "{site} news"
 msgstr ""
 
@@ -671,6 +683,7 @@ msgid "Subscribe to our newsletter"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/newsletter.html:13
+#, python-brace-format
 msgid ""
 "To stay up to date about {site} and open data news, subscribe to our "
 "newsletter and follow our events."
@@ -786,12 +799,14 @@ msgid "Add a client"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/api/card.html:9
+#, python-brace-format
 msgid ""
 "See on <a target=\"_blank\" rel=\"noopener\" title=\"See {title} on "
 "api.gouv.fr - opens a new window\" href=\"{url}\">api.gouv.fr</a>"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/api/card.html:18
+#, python-brace-format
 msgid "From {producer}"
 msgstr ""
 
@@ -1092,6 +1107,7 @@ msgid "This dataset has been archived."
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/display.html:135
+#, python-brace-format
 msgid ""
 "This dataset has been published on the initiative and under the "
 "responsibility of {author}."
@@ -1102,12 +1118,14 @@ msgid "Attributions"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/display.html:150
+#, python-brace-format
 msgid ""
 "This dataset come from an external portal.&nbsp;<a href='{external_source}' "
 "rel='ugc nofollow noopener'>View the original source.</a>"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/display.html:158
+#, python-brace-format
 msgid ""
 "This dataset is handled by the <a href='{geo_link}'>geo.data.gouv.fr</a> "
 "platform.\n"
@@ -1262,6 +1280,7 @@ msgid "The dataset files are following the schema: "
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/dataset/display.html:637
+#, python-brace-format
 msgid ""
 "Schemas allow to describe data models,\n"
 "                                discover how schemas improve your data "
@@ -1441,6 +1460,7 @@ msgstr ""
 
 #: udata_front/theme/gouvfr/templates/errors/400.html:8
 #: udata_front/theme/gouvfr/templates/errors/500.html:8
+#, python-brace-format
 msgid "The error identifier is {id}"
 msgstr ""
 
@@ -1508,6 +1528,7 @@ msgid "Share, improve and reuse public data"
 msgstr ""
 
 #: udata_front/theme/gouvfr/templates/macros/metadata.html:65
+#, python-brace-format
 msgid "udata-front@{version}"
 msgstr ""
 
@@ -2586,7 +2607,7 @@ msgid_plural "%(num)d Main files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/views/dataset.py:157
+#: udata_front/views/dataset.py:155
 #, python-format
 msgid "%(num)d Documentation"
 msgid_plural "%(num)d Documentations"
@@ -2600,7 +2621,7 @@ msgid_plural "%(num)d Updates"
 msgstr[0] ""
 msgstr[1] ""
 
-#: udata_front/views/dataset.py:164
+#: udata_front/views/dataset.py:162
 #, python-format
 msgid "%(num)d Code repository"
 msgid_plural "%(num)d Code repositories"


### PR DESCRIPTION
Fix non-deterministic translation of Getting Started that is sometimes returned in English with French locale.

![image](https://github.com/user-attachments/assets/302de90e-82a8-4b97-aeed-aefc837ac4dd)

I was able to reproduce it locally with redis cache activated, but I'm not sure to understand why it happens with cache only.

In any case, I don't think we should use python `.format()` on a localized string?