### PR TITLE
Use csv queryset instead of .visible for csv routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Use csv queryset instead of .visible for csv routes [#685](https://github.com/datagouv/udata-front/pull/685)
 
 ## 6.2.1 (2025-04-11)
 

--- a/udata_front/tests/views/test_site.py
+++ b/udata_front/tests/views/test_site.py
@@ -89,6 +89,7 @@ class SiteViewsTest(GouvfrFrontTestCase):
         self.app.config['EXPORT_CSV_MODELS'] = []
         datasets = [DatasetFactory(resources=[ResourceFactory()])
                     for _ in range(5)]
+        archived_datasets = [DatasetFactory(archived=datetime.utcnow()) for _ in range(3)]
         hidden_dataset = DatasetFactory(private=True)
 
         response = self.get(url_for('site.datasets_csv'))
@@ -112,7 +113,7 @@ class SiteViewsTest(GouvfrFrontTestCase):
         rows = list(reader)
         ids = [row[0] for row in rows]
 
-        self.assertEqual(len(rows), len(datasets))
+        self.assertEqual(len(rows), len(datasets) + len(archived_datasets))
         for dataset in datasets:
             self.assertIn(str(dataset.id), ids)
         self.assertNotIn(str(hidden_dataset.id), ids)
@@ -316,7 +317,8 @@ class SiteViewsTest(GouvfrFrontTestCase):
         self.app.config['EXPORT_CSV_MODELS'] = []
         reuses = [ReuseFactory(datasets=[DatasetFactory()])
                   for _ in range(5)]
-        hidden_reuse = ReuseFactory()
+        archived_reuses = [ReuseFactory(archived=datetime.utcnow()) for _ in range(3)]
+        hidden_reuse = ReuseFactory(private=True)
 
         response = self.get(url_for('site.reuses_csv'))
 
@@ -339,7 +341,7 @@ class SiteViewsTest(GouvfrFrontTestCase):
         rows = list(reader)
         ids = [row[0] for row in rows]
 
-        self.assertEqual(len(rows), len(reuses))
+        self.assertEqual(len(rows), len(reuses) + len(archived_reuses))
         for reuse in reuses:
             self.assertIn(str(reuse.id), ids)
         self.assertNotIn(str(hidden_reuse.id), ids)
@@ -365,7 +367,7 @@ class SiteViewsTest(GouvfrFrontTestCase):
             for _ in range(6)]
         reuses = [ReuseFactory(datasets=[DatasetFactory()])
                   for _ in range(3)]
-        hidden_reuse = ReuseFactory()
+        hidden_reuse = ReuseFactory(private=True)
 
         response = self.get(
             url_for('site.reuses_csv', tag='selected', page_size=3))
@@ -402,6 +404,8 @@ class SiteViewsTest(GouvfrFrontTestCase):
         self.app.config['EXPORT_CSV_MODELS'] = []
         dataservices = [DataserviceFactory(datasets=[DatasetFactory()])
                         for _ in range(5)]
+        archived_dataservices = [DataserviceFactory(archived_at=datetime.utcnow()) for _ in range(3)]
+        hidden_dataservice = DataserviceFactory(private=True)
 
         response = self.get(url_for('site.dataservices_csv'))
 
@@ -424,9 +428,10 @@ class SiteViewsTest(GouvfrFrontTestCase):
         rows = list(reader)
         ids = [row[0] for row in rows]
 
-        self.assertEqual(len(rows), len(dataservices))
+        self.assertEqual(len(rows), len(dataservices) + len(archived_dataservices))
         for dataservice in dataservices:
             self.assertIn(str(dataservice.id), ids)
+        self.assertNotIn(str(hidden_dataservice.id), ids)
 
     @pytest.mark.usefixtures('instance_path')
     def test_dataservices_csv_w_export_csv_feature(self):

--- a/udata_front/tests/views/test_site.py
+++ b/udata_front/tests/views/test_site.py
@@ -404,7 +404,8 @@ class SiteViewsTest(GouvfrFrontTestCase):
         self.app.config['EXPORT_CSV_MODELS'] = []
         dataservices = [DataserviceFactory(datasets=[DatasetFactory()])
                         for _ in range(5)]
-        archived_dataservices = [DataserviceFactory(archived_at=datetime.utcnow()) for _ in range(3)]
+        archived_dataservices = [DataserviceFactory(archived_at=datetime.utcnow())
+                                 for _ in range(3)]
         hidden_dataservice = DataserviceFactory(private=True)
 
         response = self.get(url_for('site.dataservices_csv'))

--- a/udata_front/views/site.py
+++ b/udata_front/views/site.py
@@ -13,6 +13,7 @@ from udata.core.dataset.api import DatasetApiParser
 from udata.core.dataset.csv import ResourcesCsvAdapter
 from udata.core.dataset.models import Dataset
 from udata.core.dataset.search import DatasetSearch
+from udata.core.dataset.tasks import get_queryset as get_csv_queryset
 from udata.core.organization.api import OrgApiParser
 from udata.core.organization.csv import OrganizationCsvAdapter
 from udata.core.organization.models import Organization
@@ -132,7 +133,7 @@ def datasets_csv():
     search_parser = DatasetSearch.as_request_parser(store_missing=False)
     params = search_parser.parse_args()
     params['facets'] = False
-    datasets = DatasetApiParser.parse_filters(Dataset.objects.visible(), params)
+    datasets = DatasetApiParser.parse_filters(get_csv_queryset(Dataset), params)
     adapter = csv.get_adapter(Dataset)
     return csv.stream(adapter(datasets), 'datasets')
 
@@ -146,7 +147,7 @@ def resources_csv():
     search_parser = DatasetSearch.as_request_parser(store_missing=False)
     params = search_parser.parse_args()
     params['facets'] = False
-    datasets = DatasetApiParser.parse_filters(Dataset.objects.visible(), params)
+    datasets = DatasetApiParser.parse_filters(get_csv_queryset(Dataset), params)
     return csv.stream(ResourcesCsvAdapter(datasets), 'resources')
 
 
@@ -158,7 +159,7 @@ def organizations_csv():
     if not params and 'organization' in exported_models:
         return redirect(get_export_url('organization'))
     params['facets'] = False
-    organizations = OrgApiParser.parse_filters(Organization.objects.visible(), params)
+    organizations = OrgApiParser.parse_filters(get_csv_queryset(Organization), params)
     return csv.stream(OrganizationCsvAdapter(organizations), 'organizations')
 
 
@@ -170,7 +171,7 @@ def reuses_csv():
     if not params and 'reuse' in exported_models:
         return redirect(get_export_url('reuse'))
     params['facets'] = False
-    reuses = ReuseApiParser.parse_filters(Reuse.objects.visible(), params)
+    reuses = ReuseApiParser.parse_filters(get_csv_queryset(Reuse), params)
     return csv.stream(ReuseCsvAdapter(reuses), 'reuses')
 
 
@@ -182,7 +183,7 @@ def dataservices_csv():
     if not params and 'dataservice' in exported_models:
         return redirect(get_export_url('dataservice'))
     params['facets'] = False
-    dataservices = Dataservice.apply_sort_filters(Dataservice.objects.visible())
+    dataservices = Dataservice.apply_sort_filters(get_csv_queryset(Dataservice))
     return csv.stream(DataserviceCsvAdapter(dataservices), 'dataservices')
 
 
@@ -192,9 +193,7 @@ def harvests_csv():
     exported_models = current_app.config.get('EXPORT_CSV_MODELS', [])
     if 'harvest' in exported_models:
         return redirect(get_export_url('harvest'))
-    adapter = HarvestSourceCsvAdapter(
-        HarvestSource.objects.filter(deleted=None).order_by('created_at')
-    )
+    adapter = HarvestSourceCsvAdapter(get_csv_queryset(HarvestSource).order_by('created_at'))
     return csv.stream(adapter, 'harvest')
 
 


### PR DESCRIPTION
We should use the same queryset as in exported catalogs built by `export-csv` job.

Indeed, now we don't have the same visibility rules, excluding archived datasets in `/datasets.csv` route whereas they are included in the daily exported catalog.